### PR TITLE
strip out xr.Dataset type hints

### DIFF
--- a/ocf_data_sampler/load/gsp.py
+++ b/ocf_data_sampler/load/gsp.py
@@ -29,5 +29,3 @@ def open_gsp(zarr_path: str | Path) -> xr.DataArray:
     )
 
     return ds.generation_mw
-
-

--- a/ocf_data_sampler/load/nwp/providers/ecmwf.py
+++ b/ocf_data_sampler/load/nwp/providers/ecmwf.py
@@ -4,6 +4,7 @@ import xarray as xr
 from ocf_data_sampler.load.nwp.providers.utils import open_zarr_paths
 from ocf_data_sampler.load.utils import check_time_unique_increasing, make_spatial_coords_increasing
 
+
 def open_ifs(zarr_path: Path | str | list[Path] | list[str]) -> xr.DataArray:
     """
     Opens the ECMWF IFS NWP data
@@ -25,7 +26,7 @@ def open_ifs(zarr_path: Path | str | list[Path] | list[str]) -> xr.DataArray:
         }
     )
 
-    # Check the timestmps are unique and increasing
+    # Check the timestamps are unique and increasing
     check_time_unique_increasing(ds.init_time_utc)
 
     # Make sure the spatial coords are in increasing order

--- a/ocf_data_sampler/load/nwp/providers/ukv.py
+++ b/ocf_data_sampler/load/nwp/providers/ukv.py
@@ -31,7 +31,7 @@ def open_ukv(zarr_path: Path | str | list[Path] | list[str]) -> xr.DataArray:
         }
     )
 
-    # Check the timestmps are unique and increasing
+    # Check the timestamps are unique and increasing
     check_time_unique_increasing(ds.init_time_utc)
 
     # Make sure the spatial coords are in increasing order

--- a/ocf_data_sampler/load/satellite.py
+++ b/ocf_data_sampler/load/satellite.py
@@ -3,12 +3,11 @@
 import subprocess
 from pathlib import Path
 
-import pandas as pd
 import xarray as xr
 from ocf_data_sampler.load.utils import check_time_unique_increasing, make_spatial_coords_increasing
 
 
-def _get_single_sat_data(zarr_path: Path | str) -> xr.DataArray:
+def _get_single_sat_data(zarr_path: Path | str) -> xr.Dataset:
     """Helper function to open a zarr from either local or GCP path.
 
     The local or GCP path may contain wildcard matching (*)
@@ -89,7 +88,7 @@ def open_sat_data(zarr_path: Path | str | list[Path] | list[str]) -> xr.DataArra
         }
     )
 
-    # Check the timestmps are unique and increasing
+    # Check the timestamps are unique and increasing
     check_time_unique_increasing(ds.time_utc)
 
     # Make sure the spatial coords are in increasing order

--- a/ocf_data_sampler/load/utils.py
+++ b/ocf_data_sampler/load/utils.py
@@ -7,6 +7,7 @@ def check_time_unique_increasing(datetimes) -> None:
     assert time.is_unique
     assert time.is_monotonic_increasing
 
+
 def make_spatial_coords_increasing(ds: xr.Dataset, x_coord: str, y_coord: str) -> xr.Dataset:
     """Make sure the spatial coordinates are in increasing order
     

--- a/ocf_data_sampler/select/dropout.py
+++ b/ocf_data_sampler/select/dropout.py
@@ -27,7 +27,7 @@ def draw_dropout_time(
 
 
 def apply_dropout_time(
-        ds: xr.Dataset,
+        ds: xr.DataArray,
         dropout_time: pd.Timestamp | None,
     ):
 

--- a/ocf_data_sampler/select/select_time_slice.py
+++ b/ocf_data_sampler/select/select_time_slice.py
@@ -37,7 +37,7 @@ def _sel_fillinterp(
 
 
 def select_time_slice(
-    ds: xr.Dataset | xr.DataArray,
+    ds: xr.DataArray,
     t0: pd.Timestamp,
     sample_period_duration: pd.Timedelta,
     history_duration: pd.Timedelta | None = None,

--- a/ocf_data_sampler/select/select_time_slice.py
+++ b/ocf_data_sampler/select/select_time_slice.py
@@ -75,7 +75,7 @@ def select_time_slice(
 
 
 def select_time_slice_nwp(
-    ds: xr.Dataset | xr.DataArray,
+    ds: xr.DataArray,
     t0: pd.Timestamp,
     sample_period_duration: pd.Timedelta,
     history_duration: pd.Timedelta,

--- a/tests/select/test_dropout.py
+++ b/tests/select/test_dropout.py
@@ -64,6 +64,7 @@ def test_draw_dropout_time_none():
     dropout_time = draw_dropout_time(t0, dropout_timedeltas=None, dropout_frac=0)
     assert dropout_time is None
 
+
 @pytest.mark.parametrize("t0_str", ["12:00", "12:30", "13:00"])
 def test_apply_dropout_time(da_sample, t0_str):
     dropout_time = pd.Timestamp(f"2024-01-01 {t0_str}")


### PR DESCRIPTION
# Pull Request

## Description

All data sources are currently loaded as `xr.DataArray`, so stripped out `xr.Dataset` hints where appropriate (basically everywhere except for functions called inside loaders that do operate on a ds)


## How Has This Been Tested?

Ran built-in tests

- [X] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
