### PR TITLE
rm prefixes and add cleaner imports fo batchkeys

### DIFF
--- a/ocf_data_sampler/numpy_batch/__init__.py
+++ b/ocf_data_sampler/numpy_batch/__init__.py
@@ -1,7 +1,7 @@
 """Conversion from Xarray to NumpyBatch"""
 
-from .gsp import convert_gsp_to_numpy_batch
-from .nwp import convert_nwp_to_numpy_batch
-from .satellite import convert_satellite_to_numpy_batch
+from .gsp import convert_gsp_to_numpy_batch, GSPBatchKey
+from .nwp import convert_nwp_to_numpy_batch, NWPBatchKey
+from .satellite import convert_satellite_to_numpy_batch, SatelliteBatchKey
 from .sun_position import make_sun_position_numpy_batch
 

--- a/ocf_data_sampler/numpy_batch/gsp.py
+++ b/ocf_data_sampler/numpy_batch/gsp.py
@@ -6,15 +6,15 @@ import xarray as xr
 class GSPBatchKey:
 
     gsp = 'gsp'
-    gsp_nominal_capacity_mwp = 'gsp_nominal_capacity_mwp'
-    gsp_effective_capacity_mwp = 'gsp_effective_capacity_mwp'
-    gsp_time_utc = 'gsp_time_utc'
-    gsp_t0_idx = 'gsp_t0_idx'
-    gsp_solar_azimuth = 'gsp_solar_azimuth'
-    gsp_solar_elevation = 'gsp_solar_elevation'
+    nominal_capacity_mwp = 'gsp_nominal_capacity_mwp'
+    effective_capacity_mwp = 'gsp_effective_capacity_mwp'
+    time_utc = 'gsp_time_utc'
+    t0_idx = 'gsp_t0_idx'
+    solar_azimuth = 'gsp_solar_azimuth'
+    solar_elevation = 'gsp_solar_elevation'
     gsp_id = 'gsp_id'
-    gsp_x_osgb = 'gsp_x_osgb'
-    gsp_y_osgb = 'gsp_y_osgb'
+    x_osgb = 'gsp_x_osgb'
+    y_osgb = 'gsp_y_osgb'
 
 
 def convert_gsp_to_numpy_batch(da: xr.DataArray, t0_idx: int | None = None) -> dict:
@@ -22,12 +22,12 @@ def convert_gsp_to_numpy_batch(da: xr.DataArray, t0_idx: int | None = None) -> d
 
     example = {
         GSPBatchKey.gsp: da.values,
-        GSPBatchKey.gsp_nominal_capacity_mwp: da.isel(time_utc=0)["nominal_capacity_mwp"].values,
-        GSPBatchKey.gsp_effective_capacity_mwp: da.isel(time_utc=0)["effective_capacity_mwp"].values,
-        GSPBatchKey.gsp_time_utc: da["time_utc"].values.astype(float),
+        GSPBatchKey.nominal_capacity_mwp: da.isel(time_utc=0)["nominal_capacity_mwp"].values,
+        GSPBatchKey.effective_capacity_mwp: da.isel(time_utc=0)["effective_capacity_mwp"].values,
+        GSPBatchKey.time_utc: da["time_utc"].values.astype(float),
     }
 
     if t0_idx is not None:
-        example[GSPBatchKey.gsp_t0_idx] = t0_idx
+        example[GSPBatchKey.t0_idx] = t0_idx
 
     return example

--- a/ocf_data_sampler/numpy_batch/nwp.py
+++ b/ocf_data_sampler/numpy_batch/nwp.py
@@ -7,13 +7,13 @@ import xarray as xr
 class NWPBatchKey:
 
     nwp = 'nwp'
-    nwp_channel_names = 'nwp_channel_names'
-    nwp_init_time_utc = 'nwp_init_time_utc'
-    nwp_step = 'nwp_step'
-    nwp_target_time_utc = 'nwp_target_time_utc'
-    nwp_t0_idx = 'nwp_t0_idx'
-    nwp_y_osgb = 'nwp_y_osgb'
-    nwp_x_osgb = 'nwp_x_osgb'
+    channel_names = 'nwp_channel_names'
+    init_time_utc = 'nwp_init_time_utc'
+    step = 'nwp_step'
+    target_time_utc = 'nwp_target_time_utc'
+    t0_idx = 'nwp_t0_idx'
+    y_osgb = 'nwp_y_osgb'
+    x_osgb = 'nwp_x_osgb'
 
 
 def convert_nwp_to_numpy_batch(da: xr.DataArray, t0_idx: int | None = None) -> dict:
@@ -21,23 +21,23 @@ def convert_nwp_to_numpy_batch(da: xr.DataArray, t0_idx: int | None = None) -> d
 
     example = {
         NWPBatchKey.nwp: da.values,
-        NWPBatchKey.nwp_channel_names: da.channel.values,
-        NWPBatchKey.nwp_init_time_utc: da.init_time_utc.values.astype(float),
-        NWPBatchKey.nwp_step: (da.step.values / pd.Timedelta("1h")).astype(int),
+        NWPBatchKey.channel_names: da.channel.values,
+        NWPBatchKey.init_time_utc: da.init_time_utc.values.astype(float),
+        NWPBatchKey.step: (da.step.values / pd.Timedelta("1h")).astype(int),
     }
 
     if "target_time_utc" in da.coords:
-        example[NWPBatchKey.nwp_target_time_utc] = da.target_time_utc.values.astype(float)
+        example[NWPBatchKey.target_time_utc] = da.target_time_utc.values.astype(float)
 
     # TODO: Do we need this at all? Especially since it is only present in UKV data
     for batch_key, dataset_key in (
-        (NWPBatchKey.nwp_y_osgb, "y_osgb"),
-        (NWPBatchKey.nwp_x_osgb, "x_osgb"),
+        (NWPBatchKey.y_osgb, "y_osgb"),
+        (NWPBatchKey.x_osgb, "x_osgb"),
     ):
         if dataset_key in da.coords:
             example[batch_key] = da[dataset_key].values
 
     if t0_idx is not None:
-        example[NWPBatchKey.nwp_t0_idx] = t0_idx
+        example[NWPBatchKey.t0_idx] = t0_idx
 
     return example

--- a/ocf_data_sampler/numpy_batch/satellite.py
+++ b/ocf_data_sampler/numpy_batch/satellite.py
@@ -5,26 +5,26 @@ import xarray as xr
 class SatelliteBatchKey:
 
     satellite_actual = 'satellite_actual'
-    satellite_time_utc = 'satellite_time_utc'
-    satellite_x_geostationary = 'satellite_x_geostationary'
-    satellite_y_geostationary = 'satellite_y_geostationary'
-    satellite_t0_idx = 'satellite_t0_idx'
+    time_utc = 'satellite_time_utc'
+    x_geostationary = 'satellite_x_geostationary'
+    y_geostationary = 'satellite_y_geostationary'
+    t0_idx = 'satellite_t0_idx'
 
 
 def convert_satellite_to_numpy_batch(da: xr.DataArray, t0_idx: int | None = None) -> dict:
     """Convert from Xarray to NumpyBatch"""
     example = {
         SatelliteBatchKey.satellite_actual: da.values,
-        SatelliteBatchKey.satellite_time_utc: da.time_utc.values.astype(float),
+        SatelliteBatchKey.time_utc: da.time_utc.values.astype(float),
     }
 
     for batch_key, dataset_key in (
-         (SatelliteBatchKey.satellite_x_geostationary, "x_geostationary"),
-        (SatelliteBatchKey.satellite_y_geostationary, "y_geostationary"),
+         (SatelliteBatchKey.x_geostationary, "x_geostationary"),
+        (SatelliteBatchKey.y_geostationary, "y_geostationary"),
     ):
         example[batch_key] = da[dataset_key].values
 
     if t0_idx is not None:
-        example[SatelliteBatchKey.satellite_t0_idx] = t0_idx
+        example[SatelliteBatchKey.t0_idx] = t0_idx
 
     return example

--- a/ocf_data_sampler/torch_datasets/pvnet_uk_regional.py
+++ b/ocf_data_sampler/torch_datasets/pvnet_uk_regional.py
@@ -24,12 +24,12 @@ from ocf_data_sampler.numpy_batch import (
     convert_nwp_to_numpy_batch,
     convert_satellite_to_numpy_batch,
     make_sun_position_numpy_batch,
+    NWPBatchKey,
+    GSPBatchKey,
 )
 
 
 from ocf_data_sampler.config import Configuration, load_yaml_configuration
-from ocf_data_sampler.numpy_batch.nwp import NWPBatchKey
-from ocf_data_sampler.numpy_batch.gsp import GSPBatchKey
 
 from ocf_data_sampler.select.location import Location
 from ocf_data_sampler.select.geospatial import osgb_to_lon_lat
@@ -426,8 +426,8 @@ def process_and_combine_datasets(
     # TODO: Do we need all of these?
     numpy_modalities.append({
         GSPBatchKey.gsp_id: location.id,
-        GSPBatchKey.gsp_x_osgb: location.x,
-        GSPBatchKey.gsp_y_osgb: location.y,
+        GSPBatchKey.x_osgb: location.x,
+        GSPBatchKey.y_osgb: location.y,
     })
 
     # Combine all the modalities and fill NaNs

--- a/tests/numpy_batch/test_gsp.py
+++ b/tests/numpy_batch/test_gsp.py
@@ -1,7 +1,6 @@
 from ocf_data_sampler.load.gsp import open_gsp
 
-from ocf_data_sampler.numpy_batch import convert_gsp_to_numpy_batch
-from ocf_data_sampler.numpy_batch.gsp import GSPBatchKey
+from ocf_data_sampler.numpy_batch import convert_gsp_to_numpy_batch, GSPBatchKey
 
 def test_convert_gsp_to_numpy_batch(uk_gsp_zarr_path):
 

--- a/tests/numpy_batch/test_nwp.py
+++ b/tests/numpy_batch/test_nwp.py
@@ -4,9 +4,7 @@ import xarray as xr
 
 import pytest
 
-from ocf_data_sampler.numpy_batch import convert_nwp_to_numpy_batch
-
-from ocf_data_sampler.numpy_batch.nwp import NWPBatchKey
+from ocf_data_sampler.numpy_batch import convert_nwp_to_numpy_batch, NWPBatchKey
 
 @pytest.fixture(scope="module")
 def da_nwp_like():

--- a/tests/numpy_batch/test_satellite.py
+++ b/tests/numpy_batch/test_satellite.py
@@ -5,9 +5,7 @@ import xarray as xr
 
 import pytest
 
-from ocf_data_sampler.numpy_batch import convert_satellite_to_numpy_batch
-
-from ocf_data_sampler.numpy_batch.satellite import SatelliteBatchKey
+from ocf_data_sampler.numpy_batch import convert_satellite_to_numpy_batch, SatelliteBatchKey
 
 
 @pytest.fixture(scope="module")

--- a/tests/numpy_batch/test_sun_position.py
+++ b/tests/numpy_batch/test_sun_position.py
@@ -6,7 +6,7 @@ from ocf_data_sampler.numpy_batch.sun_position import (
     calculate_azimuth_and_elevation, make_sun_position_numpy_batch
 )
 
-from ocf_data_sampler.numpy_batch.gsp import GSPBatchKey
+from ocf_data_sampler.numpy_batch import GSPBatchKey
 
 
 @pytest.mark.parametrize("lat", [0, 5, 10, 23.5])
@@ -71,11 +71,11 @@ def test_make_sun_position_numpy_batch():
 
     batch = make_sun_position_numpy_batch(datetimes, lon, lat, key_prefix="gsp")
 
-    assert GSPBatchKey.gsp_solar_elevation in batch
-    assert GSPBatchKey.gsp_solar_azimuth in batch
+    assert GSPBatchKey.solar_elevation in batch
+    assert GSPBatchKey.solar_azimuth in batch
 
     # The solar coords are normalised in the function
-    assert (batch[GSPBatchKey.gsp_solar_elevation]>=0).all()
-    assert (batch[GSPBatchKey.gsp_solar_elevation]<=1).all()
-    assert (batch[GSPBatchKey.gsp_solar_azimuth]>=0).all()
-    assert (batch[GSPBatchKey.gsp_solar_azimuth]<=1).all()
+    assert (batch[GSPBatchKey.solar_elevation]>=0).all()
+    assert (batch[GSPBatchKey.solar_elevation]<=1).all()
+    assert (batch[GSPBatchKey.solar_azimuth]>=0).all()
+    assert (batch[GSPBatchKey.solar_azimuth]<=1).all()

--- a/tests/torch_datasets/test_pvnet_uk_regional.py
+++ b/tests/torch_datasets/test_pvnet_uk_regional.py
@@ -3,9 +3,7 @@ import tempfile
 
 from ocf_data_sampler.torch_datasets.pvnet_uk_regional import PVNetUKRegionalDataset
 from ocf_data_sampler.config import load_yaml_configuration, save_yaml_configuration
-from ocf_data_sampler.numpy_batch.nwp import NWPBatchKey
-from ocf_data_sampler.numpy_batch.gsp import GSPBatchKey
-from ocf_data_sampler.numpy_batch.satellite import SatelliteBatchKey
+from ocf_data_sampler.numpy_batch import NWPBatchKey, GSPBatchKey, SatelliteBatchKey
 
 
 @pytest.fixture()
@@ -39,7 +37,7 @@ def test_pvnet(pvnet_config_filename):
 
     for key in [
         NWPBatchKey.nwp, SatelliteBatchKey.satellite_actual, GSPBatchKey.gsp,
-        GSPBatchKey.gsp_solar_azimuth, GSPBatchKey.gsp_solar_elevation,
+        GSPBatchKey.solar_azimuth, GSPBatchKey.solar_elevation,
     ]:
         assert key in sample
     
@@ -54,8 +52,8 @@ def test_pvnet(pvnet_config_filename):
     # 3 hours of 30 minute data (inclusive)
     assert sample[GSPBatchKey.gsp].shape == (7,)
     # Solar angles have same shape as GSP data
-    assert sample[GSPBatchKey.gsp_solar_azimuth].shape == (7,)
-    assert sample[GSPBatchKey.gsp_solar_elevation].shape == (7,)
+    assert sample[GSPBatchKey.solar_azimuth].shape == (7,)
+    assert sample[GSPBatchKey.solar_elevation].shape == (7,)
 
 def test_pvnet_no_gsp(pvnet_config_filename):
 


### PR DESCRIPTION
# Pull Request

## Description

- Add imports from numpy_batch instead of numpy_batch.[source]
- remove prefixes from batchkeys

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
