### PR TITLE
Site torch dataset update

### DIFF
--- a/ocf_data_sampler/torch_datasets/process_and_combine.py
+++ b/ocf_data_sampler/torch_datasets/process_and_combine.py
@@ -10,7 +10,6 @@ from ocf_data_sampler.numpy_batch import (
     convert_satellite_to_numpy_batch,
     convert_gsp_to_numpy_batch,
     make_sun_position_numpy_batch,
-    convert_site_to_numpy_batch,
 )
 from ocf_data_sampler.numpy_batch.gsp import GSPBatchKey
 from ocf_data_sampler.numpy_batch.nwp import NWPBatchKey
@@ -74,18 +73,6 @@ def process_and_combine_datasets(
             }
         )
 
-
-    if "site" in dataset_dict:
-        site_config = config.input_data.site
-        da_sites = dataset_dict["site"]
-        da_sites = da_sites / da_sites.capacity_kwp
-
-        numpy_modalities.append(
-            convert_site_to_numpy_batch(
-                da_sites, t0_idx=-site_config.interval_start_minutes / site_config.time_resolution_minutes
-            )
-        )
-
     if target_key == 'gsp':
         # Make sun coords NumpyBatch
         datetimes = pd.date_range(
@@ -95,16 +82,6 @@ def process_and_combine_datasets(
         )
 
         lon, lat = osgb_to_lon_lat(location.x, location.y)
-
-    elif target_key == 'site':
-        # Make sun coords NumpyBatch
-        datetimes = pd.date_range(
-            t0+minutes(site_config.interval_start_minutes),
-            t0+minutes(site_config.interval_end_minutes),
-            freq=minutes(site_config.time_resolution_minutes),
-        )
-
-        lon, lat = location.x, location.y
 
     numpy_modalities.append(
         make_sun_position_numpy_batch(datetimes, lon, lat, key_prefix=target_key)

--- a/ocf_data_sampler/torch_datasets/process_and_combine.py
+++ b/ocf_data_sampler/torch_datasets/process_and_combine.py
@@ -120,7 +120,17 @@ def process_and_combine_site_sample_dict(
     dataset_dict: dict,
     config: Configuration,
 ) -> xr.Dataset:
-    """Normalize and combine data to xr Dataset"""
+    """
+    Normalize and combine data into a single xr Dataset
+
+    Args:
+        dataset_dict: dict containing sliced xr DataArrays
+        config: Configuration for the model
+
+    Returns:
+        xr.Dataset: A merged Dataset with nans filled in.
+    
+    """
 
     data_arrays = []
 
@@ -156,7 +166,7 @@ def merge_dicts(list_of_dicts: list[dict]) -> dict:
         combined_dict.update(d)
     return combined_dict
 
-def merge_arrays(list_of_arrays: list[Tuple[str, xr.DataArray]]) -> xr.Dataset:
+def merge_arrays(normalised_data_arrays: list[Tuple[str, xr.DataArray]]) -> xr.Dataset:
     """
     Combine a list of DataArrays into a single Dataset with unique naming conventions.
 
@@ -170,7 +180,7 @@ def merge_arrays(list_of_arrays: list[Tuple[str, xr.DataArray]]) -> xr.Dataset:
     """
     datasets = []
 
-    for key, data_array in list_of_arrays:
+    for key, data_array in normalised_data_arrays:
         # Ensure all attributes are strings for consistency
         data_array = data_array.assign_attrs(
             {attr_key: str(attr_value) for attr_key, attr_value in data_array.attrs.items()}

--- a/ocf_data_sampler/torch_datasets/site.py
+++ b/ocf_data_sampler/torch_datasets/site.py
@@ -152,10 +152,9 @@ class SitesDataset(Dataset):
         """
         sample_dict = slice_datasets_by_space(self.datasets_dict, location, self.config)
         sample_dict = slice_datasets_by_time(sample_dict, t0, self.config)
-        sample_dict = compute(sample_dict)
 
         sample = process_and_combine_site_sample_dict(sample_dict, self.config)
-
+        sample = sample.compute()
         return sample
 
     def get_location_from_site_id(self, site_id):

--- a/ocf_data_sampler/torch_datasets/site.py
+++ b/ocf_data_sampler/torch_datasets/site.py
@@ -15,7 +15,7 @@ from ocf_data_sampler.select import (
     slice_datasets_by_time, slice_datasets_by_space
 )
 from ocf_data_sampler.utils import minutes
-from ocf_data_sampler.torch_datasets.process_and_combine import process_and_combine_datasets, compute
+from ocf_data_sampler.torch_datasets.process_and_combine import process_and_combine_site_sample_dict, compute
 from ocf_data_sampler.torch_datasets.valid_time_periods import find_valid_time_periods
 
 xr.set_options(keep_attrs=True)
@@ -154,7 +154,7 @@ class SitesDataset(Dataset):
         sample_dict = slice_datasets_by_time(sample_dict, t0, self.config)
         sample_dict = compute(sample_dict)
 
-        sample = process_and_combine_datasets(sample_dict, self.config, t0, location, target_key='site')
+        sample = process_and_combine_site_sample_dict(sample_dict, self.config)
 
         return sample
 

--- a/ocf_data_sampler/torch_datasets/site.py
+++ b/ocf_data_sampler/torch_datasets/site.py
@@ -15,7 +15,7 @@ from ocf_data_sampler.select import (
     slice_datasets_by_time, slice_datasets_by_space
 )
 from ocf_data_sampler.utils import minutes
-from ocf_data_sampler.torch_datasets.process_and_combine import process_and_combine_site_sample_dict, compute
+from ocf_data_sampler.torch_datasets.process_and_combine import process_and_combine_site_sample_dict
 from ocf_data_sampler.torch_datasets.valid_time_periods import find_valid_time_periods
 
 xr.set_options(keep_attrs=True)

--- a/tests/select/test_select_time_slice.py
+++ b/tests/select/test_select_time_slice.py
@@ -197,7 +197,7 @@ def test_select_time_slice_nwp_with_dropout_and_accum(da_nwp_like, t0_str):
     t0 = pd.Timestamp(f"2024-01-02 {t0_str}")
     interval_start = pd.Timedelta(-6, "h")
     interval_end = pd.Timedelta(3, "h")
-    freq = pd.Timedelta("1H")
+    freq = pd.Timedelta("1h")
     dropout_timedelta = pd.Timedelta("-2h")
 
     t0_delayed = (t0 + dropout_timedelta).floor(NWP_FREQ)

--- a/tests/torch_datasets/test_site.py
+++ b/tests/torch_datasets/test_site.py
@@ -6,6 +6,7 @@ from ocf_data_sampler.config import load_yaml_configuration, save_yaml_configura
 from ocf_data_sampler.numpy_batch.nwp import NWPBatchKey
 from ocf_data_sampler.numpy_batch.site import SiteBatchKey
 from ocf_data_sampler.numpy_batch.satellite import SatelliteBatchKey
+from xarray import Dataset
 
 
 @pytest.fixture()
@@ -34,30 +35,32 @@ def test_site(site_config_filename):
     # Generate a sample
     sample = dataset[0]
 
-    assert isinstance(sample, dict)
+    assert isinstance(sample, Dataset)
 
-    for key in [
-        NWPBatchKey.nwp,
-        SatelliteBatchKey.satellite_actual,
-        SiteBatchKey.generation,
-        SiteBatchKey.site_solar_azimuth,
-        SiteBatchKey.site_solar_elevation,
-    ]:
-        assert key in sample
+    # TODO change this bit of the test to check for sensible things
 
-    for nwp_source in ["ukv"]:
-        assert nwp_source in sample[NWPBatchKey.nwp]
+    # for key in [
+    #     NWPBatchKey.nwp,
+    #     SatelliteBatchKey.satellite_actual,
+    #     SiteBatchKey.generation,
+    #     SiteBatchKey.site_solar_azimuth,
+    #     SiteBatchKey.site_solar_elevation,
+    # ]:
+    #     assert key in sample
 
-    # check the shape of the data is correct
-    # 30 minutes of 5 minute data (inclusive), one channel, 2x2 pixels
-    assert sample[SatelliteBatchKey.satellite_actual].shape == (7, 1, 2, 2)
-    # 3 hours of 60 minute data (inclusive), one channel, 2x2 pixels
-    assert sample[NWPBatchKey.nwp]["ukv"][NWPBatchKey.nwp].shape == (4, 1, 2, 2)
-    # 3 hours of 30 minute data (inclusive)
-    assert sample[SiteBatchKey.generation].shape == (4,)
-    # Solar angles have same shape as GSP data
-    assert sample[SiteBatchKey.site_solar_azimuth].shape == (4,)
-    assert sample[SiteBatchKey.site_solar_elevation].shape == (4,)
+    # for nwp_source in ["ukv"]:
+    #     assert nwp_source in sample[NWPBatchKey.nwp]
+
+    # # check the shape of the data is correct
+    # # 30 minutes of 5 minute data (inclusive), one channel, 2x2 pixels
+    # assert sample[SatelliteBatchKey.satellite_actual].shape == (7, 1, 2, 2)
+    # # 3 hours of 60 minute data (inclusive), one channel, 2x2 pixels
+    # assert sample[NWPBatchKey.nwp]["ukv"][NWPBatchKey.nwp].shape == (4, 1, 2, 2)
+    # # 3 hours of 30 minute data (inclusive)
+    # assert sample[SiteBatchKey.generation].shape == (4,)
+    # # Solar angles have same shape as GSP data
+    # assert sample[SiteBatchKey.site_solar_azimuth].shape == (4,)
+    # assert sample[SiteBatchKey.site_solar_elevation].shape == (4,)
 
 
 def test_site_time_filter_start(site_config_filename):

--- a/tests/torch_datasets/test_site.py
+++ b/tests/torch_datasets/test_site.py
@@ -37,31 +37,24 @@ def test_site(site_config_filename):
 
     assert isinstance(sample, Dataset)
 
-    # TODO change this bit of the test to check for sensible things
+    # Expected dimensions and data variables
+    expected_dims = {'satellite__x_geostationary', 'sites__time_utc', 'nwp-ukv__target_time_utc',
+                     'nwp-ukv__x_osgb', 'satellite__channel', 'satellite__y_geostationary',
+                     'satellite__time_utc', 'nwp-ukv__channel', 'nwp-ukv__y_osgb'}
+    expected_data_vars = {"nwp-ukv", "satellite", "sites"}
 
-    # for key in [
-    #     NWPBatchKey.nwp,
-    #     SatelliteBatchKey.satellite_actual,
-    #     SiteBatchKey.generation,
-    #     SiteBatchKey.site_solar_azimuth,
-    #     SiteBatchKey.site_solar_elevation,
-    # ]:
-    #     assert key in sample
+    # Check dimensions
+    assert set(sample.dims) == expected_dims, f"Missing or extra dimensions: {set(sample.dims) ^ expected_dims}"
+    # Check data variables
+    assert set(sample.data_vars) == expected_data_vars, f"Missing or extra data variables: {set(sample.data_vars) ^ expected_data_vars}"
 
-    # for nwp_source in ["ukv"]:
-    #     assert nwp_source in sample[NWPBatchKey.nwp]
-
-    # # check the shape of the data is correct
-    # # 30 minutes of 5 minute data (inclusive), one channel, 2x2 pixels
-    # assert sample[SatelliteBatchKey.satellite_actual].shape == (7, 1, 2, 2)
-    # # 3 hours of 60 minute data (inclusive), one channel, 2x2 pixels
-    # assert sample[NWPBatchKey.nwp]["ukv"][NWPBatchKey.nwp].shape == (4, 1, 2, 2)
-    # # 3 hours of 30 minute data (inclusive)
-    # assert sample[SiteBatchKey.generation].shape == (4,)
-    # # Solar angles have same shape as GSP data
-    # assert sample[SiteBatchKey.site_solar_azimuth].shape == (4,)
-    # assert sample[SiteBatchKey.site_solar_elevation].shape == (4,)
-
+    # check the shape of the data is correct
+    # 30 minutes of 5 minute data (inclusive), one channel, 2x2 pixels
+    assert sample["satellite"].values.shape == (7, 1, 2, 2)
+    # 3 hours of 60 minute data (inclusive), one channel, 2x2 pixels
+    assert sample["nwp-ukv"].values.shape == (4, 1, 2, 2)
+    # 1.5 hours of 30 minute data (inclusive)
+    assert sample["sites"].values.shape == (4,)
 
 def test_site_time_filter_start(site_config_filename):
 


### PR DESCRIPTION
# Pull Request

## Description

WIP PR to update the Site Torch Dataset to return samples as xarray Datasets for easier conversion into netcdf files which is the preferred current format of saving samples.  

This PR includes:

- Adding a new functions to process the sample dict (dict with xr DataArrays) into one Dataset
- Reordering of when .compute() is called since now we combine multiple DataArrays into a Dataset we can call compute after this is done
- Removed unused site specific parts from original process and combine function
- Updating unit tests now that the data type of the sample has changes in the Torch Dataset
- Updating some time interval syntax to stop a deprecation warning (unrelated to the above changes)

TODO 
- Removed saving solar coordinates data in samples for now, current idea is to use the numpy batch functions in here in PVNet to create this data when converting to a numpy batch (if this seems messy may add some logic in here to add to the solar position coordinates to the Dataset)
- Check this works by creating some samples and adding logic into PVNet to read the netcdfs and convert to NumpyBatch/TensorBatches and then train a model, will link PR here once that is done

