### PR TITLE
Fix broken link in torch datasets documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ We are currently migrating to this repo from [ocf_datapipes](https://github.com/
 
 ## Documentation
 
-**ocf-data-sampler** doesn't have external documentation _yet_; you can read a bit about how our torch datasets work in the Readme [here](https://github.com/openclimatefix/ocf-data-sampler/tree/readme-update/ocf_data_sampler/torch_datasets).
+**ocf-data-sampler** doesn't have external documentation _yet_; you can read a bit about how our torch datasets work in the Readme [here]([torch datasets documentation](https://github.com/openclimatefix/ocf-data-sampler/blob/07f412cd125a154c527444a5ff7bd0ba4ede4d30/ocf_data_sampler/torch_datasets/README.md)
+
 
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We are currently migrating to this repo from [ocf_datapipes](https://github.com/
 
 ## Documentation
 
-**ocf-data-sampler** doesn't have external documentation _yet_; you can read a bit about how our torch datasets work in the Readme [here]([torch datasets documentation](https://github.com/openclimatefix/ocf-data-sampler/blob/07f412cd125a154c527444a5ff7bd0ba4ede4d30/ocf_data_sampler/torch_datasets/README.md)
+**ocf-data-sampler** doesn't have external documentation _yet_; you can read a bit about how our torch datasets work in the Readme [here]([torch datasets documentation](ocf_data_sampler/torch_datasets/README.md)
 
 
 


### PR DESCRIPTION
Updated the broken link to reference the correct torch datasets documentation

# Pull Request

## Description

This PR resolves an issue in the torch datasets documentation where the existing link was not working as expected. The broken link has been updated to reference the correct file in the repository.

**Changes Made:**

Replaced the broken link with the correct link:
https://github.com/openclimatefix/ocf-data-sampler/blob/07f412cd125a154c527444a5ff7bd0ba4ede4d30/ocf_data_sampler/torch_datasets/README.md?plain=1#L4

**Why This Change Was Made:**

The previous link in the documentation was non-functional, making it difficult for users to access relevant details about the torch datasets.
This change ensures that users are directed to the correct location for further information.

**How to Verify:**

Click on the updated link in the torch datasets documentation.
Confirm that it takes you to the correct README file in the repository.

## Checklist:

- [ ¶] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [¶ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ¶] I have checked my code and corrected any misspellings
