### PR TITLE
 Simplify Dataset Slicing Logic and Remove unused Parameters

### DIFF
--- a/ocf_data_sampler/select/select_time_slice.py
+++ b/ocf_data_sampler/select/select_time_slice.py
@@ -2,29 +2,14 @@ import xarray as xr
 import pandas as pd
 import numpy as np
 
-def _sel_default(
-        da: xr.DataArray, 
-        start_dt: pd.Timestamp, 
-        end_dt: pd.Timestamp, 
-        sample_period_duration: pd.Timedelta,
-    ) -> xr.DataArray:
-    """Select a time slice from a DataArray, without filling missing times."""
-    return da.sel(time_utc=slice(start_dt, end_dt))
-
 def select_time_slice(
     ds: xr.DataArray,
     t0: pd.Timestamp,
     interval_start: pd.Timedelta,
     interval_end: pd.Timedelta,
     sample_period_duration: pd.Timedelta,
-    fill_selection: bool = False,
-    max_steps_gap: int = 0,
 ):
     """Select a time slice from a Dataset or DataArray."""
-    assert max_steps_gap >= 0, "max_steps_gap must be >= 0 "
-    
-    _sel = _sel_default
-
     t0_datetime_utc = pd.Timestamp(t0)
     start_dt = t0_datetime_utc + interval_start
     end_dt = t0_datetime_utc + interval_end
@@ -32,7 +17,7 @@ def select_time_slice(
     start_dt = start_dt.ceil(sample_period_duration)
     end_dt = end_dt.ceil(sample_period_duration)
 
-    return _sel(ds, start_dt, end_dt, sample_period_duration)
+    return ds.sel(time_utc=slice(start_dt, end_dt))
 
 def select_time_slice_nwp(
     da: xr.DataArray,
@@ -45,7 +30,6 @@ def select_time_slice_nwp(
     accum_channels: list[str] = [],
     channel_dim_name: str = "channel",
 ):
-
     if dropout_timedeltas is not None:
         assert all(
             [t < pd.Timedelta(0) for t in dropout_timedeltas]
@@ -54,6 +38,7 @@ def select_time_slice_nwp(
     assert 0 <= dropout_frac <= 1
     consider_dropout = (dropout_timedeltas is not None) and dropout_frac > 0
 
+     # The accumatation and non-accumulation channels
     accum_channels = np.intersect1d(
         da[channel_dim_name].values, accum_channels
     )
@@ -66,32 +51,44 @@ def select_time_slice_nwp(
 
     target_times = pd.date_range(start_dt, end_dt, freq=sample_period_duration)
 
+    # Maybe apply NWP dropout
     if consider_dropout and (np.random.uniform() < dropout_frac):
         dt = np.random.choice(dropout_timedeltas)
         t0_available = t0 + dt
     else:
         t0_available = t0
 
+    # Forecasts made up to and including t0
     available_init_times = da.init_time_utc.sel(
         init_time_utc=slice(None, t0_available)
     )
 
+    # Find the most recent available init times for all target times
     selected_init_times = available_init_times.sel(
         init_time_utc=target_times,
         method="ffill",
     ).values
 
+    # Find the required steps for all target times
     steps = target_times - selected_init_times
 
+    # We want one timestep for each target_time_hourly (obviously!) If we simply do
+    # nwp.sel(init_time=init_times, step=steps) then we'll get the *product* of
+    # init_times and steps, which is not what # we want! Instead, we use xarray's
+    # vectorized-indexing mode by using a DataArray indexer.  See the last example here:
+    # https://docs.xarray.dev/en/latest/user-guide/indexing.html#more-advanced-indexing
+    
     coords = {"target_time_utc": target_times}
     init_time_indexer = xr.DataArray(selected_init_times, coords=coords)
     step_indexer = xr.DataArray(steps, coords=coords)
 
     if len(accum_channels) == 0:
         da_sel = da.sel(step=step_indexer, init_time_utc=init_time_indexer)
-
     else:
+        # First minimise the size of the dataset we are diffing
+        # - find the init times we are slicing from
         unique_init_times = np.unique(selected_init_times)
+        # - find the min and max steps we slice over. Max is extended due to diff
         min_step = min(steps)
         max_step = max(steps) + sample_period_duration
 
@@ -102,18 +99,26 @@ def select_time_slice_nwp(
             }
         )
 
+        # Slice out the data which does not need to be diffed
         da_non_accum = da_min.sel({channel_dim_name: non_accum_channels})
         da_sel_non_accum = da_non_accum.sel(
             step=step_indexer, init_time_utc=init_time_indexer
         )
 
+        # Slice out the channels which need to be diffed
         da_accum = da_min.sel({channel_dim_name: accum_channels})
+        
+        # Take the diff and slice requested data
         da_accum = da_accum.diff(dim="step", label="lower")
         da_sel_accum = da_accum.sel(step=step_indexer, init_time_utc=init_time_indexer)
 
+        # Join diffed and non-diffed variables
         da_sel = xr.concat([da_sel_non_accum, da_sel_accum], dim=channel_dim_name)
+        
+        # Reorder the variable back to the original order
         da_sel = da_sel.sel({channel_dim_name: da[channel_dim_name].values})
 
+        # Rename the diffed channels
         da_sel[channel_dim_name] = [
             f"diff_{v}" if v in accum_channels else v
             for v in da_sel[channel_dim_name].values

--- a/ocf_data_sampler/select/time_slice_for_dataset.py
+++ b/ocf_data_sampler/select/time_slice_for_dataset.py
@@ -1,11 +1,9 @@
-""" Slice datasets by time"""
 import pandas as pd
 
 from ocf_data_sampler.config import Configuration
 from ocf_data_sampler.select.dropout import draw_dropout_time, apply_dropout_time
 from ocf_data_sampler.select.select_time_slice import select_time_slice_nwp, select_time_slice
 from ocf_data_sampler.utils import minutes
-
 
 def slice_datasets_by_time(
     datasets_dict: dict,
@@ -23,11 +21,9 @@ def slice_datasets_by_time(
     sliced_datasets_dict = {}
 
     if "nwp" in datasets_dict:
-        
         sliced_datasets_dict["nwp"] = {}
-        
+
         for nwp_key, da_nwp in datasets_dict["nwp"].items():
-                            
             nwp_config = config.input_data.nwp[nwp_key]
 
             sliced_datasets_dict["nwp"][nwp_key] = select_time_slice_nwp(
@@ -42,7 +38,6 @@ def slice_datasets_by_time(
             )
 
     if "sat" in datasets_dict:
-
         sat_config = config.input_data.satellite
 
         sliced_datasets_dict["sat"] = select_time_slice(
@@ -51,7 +46,6 @@ def slice_datasets_by_time(
             sample_period_duration=minutes(sat_config.time_resolution_minutes),
             interval_start=minutes(sat_config.interval_start_minutes),
             interval_end=minutes(sat_config.interval_end_minutes),
-            max_steps_gap=2,
         )
 
         # Randomly sample dropout
@@ -77,7 +71,7 @@ def slice_datasets_by_time(
             interval_start=minutes(gsp_config.time_resolution_minutes),
             interval_end=minutes(gsp_config.interval_end_minutes),
         )
-    
+
         sliced_datasets_dict["gsp"] = select_time_slice(
             datasets_dict["gsp"],
             t0,
@@ -97,7 +91,7 @@ def slice_datasets_by_time(
             sliced_datasets_dict["gsp"], 
             gsp_dropout_time
         )
-    
+
     if "site" in datasets_dict:
         site_config = config.input_data.site
 

--- a/tests/select/test_select_time_slice.py
+++ b/tests/select/test_select_time_slice.py
@@ -89,8 +89,12 @@ def test_select_time_slice_out_of_bounds(da_sat_like, t0_str):
     min_time = da_sat_like.time_utc.min()
     max_time = da_sat_like.time_utc.max()
 
-    # Expect to return these timestamps from the selection
-    expected_datetimes = pd.date_range(t0 + interval_start, t0 + interval_end, freq=freq)
+    # Expect to return these timestamps within the requested range
+    expected_datetimes = pd.date_range(
+        max(t0 + interval_start, min_time),
+        min(t0 + interval_end, max_time),
+        freq=freq,
+    )
 
     # Make the partially out of bounds selection
     sat_sample = select_time_slice(
@@ -99,11 +103,10 @@ def test_select_time_slice_out_of_bounds(da_sat_like, t0_str):
         interval_start=interval_start,
         interval_end=interval_end,
         sample_period_duration=freq,
-        fill_selection=True
     )
 
-    # Check the returned times are as expected
-    assert (sat_sample.time_utc == expected_datetimes).all()
+    # Validate the returned timestamps match the available range
+    assert list(sat_sample.time_utc.values) == list(expected_datetimes)
 
     
     # Check all the values before the first timestamp available in the data are NaN


### PR DESCRIPTION
# Pull Request

## Description

This PR simplifies the dataset slicing logic in the select_time_slice and select_time_slice_nwp functions by addressing unused parameters and redundant functionality. It aligns with the feedback provided by @AUdaltsova  and removes unnecessary complexity from the code.

**Changes made:**
Removed _sel_fillnan function as it is no longer required.
Simplified select_time_slice() by directly using xr.DataArray.sel() for slicing.
Removed the fill_selection parameter entirely from function definitions and calls.
Updated the test test_select_time_slice_out_of_bounds to reflect the updated slicing logic, ensuring it aligns with the new behavior.

Fixes #133 

## How Has This Been Tested?

Verified that dataset slicing works as expected with the updated logic.

- [x] Yes


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
