### PR TITLE
fix: remove key_prefix from time features

### DIFF
--- a/ocf_data_sampler/numpy_sample/datetime_features.py
+++ b/ocf_data_sampler/numpy_sample/datetime_features.py
@@ -22,7 +22,7 @@ def _get_date_time_in_pi(
     return date_in_pi, time_in_pi
 
 
-def make_datetime_numpy_dict(datetimes: pd.DatetimeIndex, key_prefix: str = "wind") -> dict:
+def make_datetime_numpy_dict(datetimes: pd.DatetimeIndex) -> dict:
     """ Make dictionary of datetime features"""
 
     if datetimes.empty:
@@ -33,14 +33,9 @@ def make_datetime_numpy_dict(datetimes: pd.DatetimeIndex, key_prefix: str = "win
     date_in_pi, time_in_pi = _get_date_time_in_pi(datetimes)
 
     # Store
-    date_sin_batch_key = key_prefix + "_date_sin"
-    date_cos_batch_key = key_prefix + "_date_cos"
-    time_sin_batch_key = key_prefix + "_time_sin"
-    time_cos_batch_key = key_prefix + "_time_cos"
-
-    time_numpy_sample[date_sin_batch_key] = np.sin(date_in_pi)
-    time_numpy_sample[date_cos_batch_key] = np.cos(date_in_pi)
-    time_numpy_sample[time_sin_batch_key] = np.sin(time_in_pi)
-    time_numpy_sample[time_cos_batch_key] = np.cos(time_in_pi)
+    time_numpy_sample["date_sin"] = np.sin(date_in_pi)
+    time_numpy_sample["date_cos"] = np.cos(date_in_pi)
+    time_numpy_sample["time_sin"] = np.sin(time_in_pi)
+    time_numpy_sample["time_cos"] = np.cos(time_in_pi)
 
     return time_numpy_sample

--- a/ocf_data_sampler/numpy_sample/sun_position.py
+++ b/ocf_data_sampler/numpy_sample/sun_position.py
@@ -1,16 +1,15 @@
-
 import pvlib
 import numpy as np
 import pandas as pd
 
 
 def calculate_azimuth_and_elevation(
-    datetimes: pd.DatetimeIndex, 
-    lon: float, 
+    datetimes: pd.DatetimeIndex,
+    lon: float,
     lat: float
 ) -> tuple[np.ndarray, np.ndarray]:
     """Calculate the solar coordinates for multiple datetimes at a single location
-    
+
     Args:
         datetimes: The datetimes to calculate for
         lon: The longitude
@@ -33,10 +32,9 @@ def calculate_azimuth_and_elevation(
 
 
 def make_sun_position_numpy_sample(
-        datetimes: pd.DatetimeIndex, 
-        lon: float, 
-        lat: float, 
-        key_prefix: str = "gsp"
+        datetimes: pd.DatetimeIndex,
+        lon: float,
+        lat: float,
 ) -> dict:
     """Creates NumpySample with standardized solar coordinates
 
@@ -45,7 +43,7 @@ def make_sun_position_numpy_sample(
         lon: The longitude
         lat: The latitude
     """
-    
+
     azimuth, elevation = calculate_azimuth_and_elevation(datetimes, lon, lat)
 
     # Normalise
@@ -53,13 +51,13 @@ def make_sun_position_numpy_sample(
     # Azimuth is in range [0, 360] degrees
     azimuth = azimuth / 360
 
-    # Elevation is in range [-90, 90] degrees
+    # Elevation is in range [-90, 90] degrees
     elevation = elevation / 180 + 0.5
-    
+
     # Make NumpySample
     sun_numpy_sample = {
-        key_prefix + "_solar_azimuth": azimuth,
-        key_prefix + "_solar_elevation": elevation,
+        "solar_azimuth": azimuth,
+        "solar_elevation": elevation,
     }
 
     return sun_numpy_sample

--- a/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
+++ b/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
@@ -105,7 +105,7 @@ def process_and_combine_datasets(
         lon, lat = osgb_to_lon_lat(location.x, location.y)
 
     numpy_modalities.append(
-        make_sun_position_numpy_sample(datetimes, lon, lat, key_prefix=target_key)
+        make_sun_position_numpy_sample(datetimes, lon, lat)
     )
 
     # Combine all the modalities and fill NaNs

--- a/ocf_data_sampler/torch_datasets/datasets/site.py
+++ b/ocf_data_sampler/torch_datasets/datasets/site.py
@@ -241,7 +241,7 @@ class SitesDataset(Dataset):
 
         # add datetime features
         datetimes = pd.DatetimeIndex(combined_sample_dataset.site__time_utc.values)
-        datetime_features = make_datetime_numpy_dict(datetimes=datetimes, key_prefix="site_")
+        datetime_features = make_datetime_numpy_dict(datetimes=datetimes)
         combined_sample_dataset = combined_sample_dataset.assign_coords(
             {k: ("site__time_utc", v) for k, v in datetime_features.items()}
         )
@@ -251,10 +251,9 @@ class SitesDataset(Dataset):
             datetimes=datetimes,
             lon=combined_sample_dataset.site__longitude.values,
             lat=combined_sample_dataset.site__latitude.values,
-            key_prefix="site_",
         )
         combined_sample_dataset = combined_sample_dataset.assign_coords(
-            {k: ("site__time_utc", v) for k, v in sun_position_features.items()}
+             {k: ("site__time_utc", v) for k, v in sun_position_features.items()}
         )
 
         # TODO include t0_index in xr dataset? 

--- a/tests/numpy_sample/test_datetime_features.py
+++ b/tests/numpy_sample/test_datetime_features.py
@@ -15,26 +15,14 @@ def test_calculate_azimuth_and_elevation():
 
     assert len(datetime_features) == 4
 
-    assert len(datetime_features["wind_date_sin"]) == len(datetimes)
-    assert (datetime_features["wind_date_cos"] != datetime_features["wind_date_sin"]).all()
+    assert len(datetime_features["date_sin"]) == len(datetimes)
+    assert (datetime_features["date_cos"] != datetime_features["date_sin"]).all()
 
     # assert all values are between -1 and 1
-    assert all(np.abs(datetime_features["wind_date_sin"]) <= 1)
-    assert all(np.abs(datetime_features["wind_date_cos"]) <= 1)
-    assert all(np.abs(datetime_features["wind_time_sin"]) <= 1)
-    assert all(np.abs(datetime_features["wind_time_cos"]) <= 1)
-
-
-def test_make_datetime_numpy_batch_custom_key_prefix():
-    # Test function correctly applies custom prefix to dict keys
-    datetimes = pd.to_datetime(["2024-06-20 12:00", "2024-06-20 12:30", "2024-06-20 13:00"])
-    key_prefix = "solar"
-
-    datetime_features = make_datetime_numpy_dict(datetimes, key_prefix=key_prefix)
-
-    # Assert dict contains expected quantity of keys and verify starting with custom prefix
-    assert len(datetime_features) == 4
-    assert all(key.startswith(key_prefix) for key in datetime_features.keys())
+    assert all(np.abs(datetime_features["date_sin"]) <= 1)
+    assert all(np.abs(datetime_features["date_cos"]) <= 1)
+    assert all(np.abs(datetime_features["time_sin"]) <= 1)
+    assert all(np.abs(datetime_features["time_cos"]) <= 1)
 
 
 def test_make_datetime_numpy_batch_empty_input():

--- a/tests/numpy_sample/test_sun_position.py
+++ b/tests/numpy_sample/test_sun_position.py
@@ -69,7 +69,7 @@ def test_make_sun_position_numpy_sample():
     datetimes = pd.date_range("2024-06-20 12:00", "2024-06-20 16:00", freq="30min")
     lon, lat = 0, 51.5
 
-    sample = make_sun_position_numpy_sample(datetimes, lon, lat, key_prefix="gsp")
+    sample = make_sun_position_numpy_sample(datetimes, lon, lat)
 
     assert GSPSampleKey.solar_elevation in sample
     assert GSPSampleKey.solar_azimuth in sample


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the `key_prefix` argument from the `make_datetime_numpy_dict` and `make_sun_position_numpy_sample` functions and updates all call sites and tests accordingly.  The `key_prefix` was originally introduced for flexibility in naming output dictionary keys, primarily within the context of the now-deprecated `ocf_datapipes` library.  Since `ocf-data-sampler` uses a different approach (PyTorch Datasets instead of DataPipes), this flexibility is no longer needed and introduces unnecessary complexity.

This PR simplifies the code by hardcoding consistent key names for the datetime and sun position features:

*   `make_datetime_numpy_dict`:  Keys are now `"date_sin"`, `"date_cos"`, `"time_sin"`, `"time_cos"`.
*   `make_sun_position_numpy_sample`: Keys are now `"solar_azimuth"`, `"solar_elevation"`.

This change improves code readability and maintainability by removing a parameter that is no longer relevant and ensuring consistent naming across the codebase.

Fixes #159 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (No docstring changes were necessary, as the functions' behavior didn't fundamentally change, only the output keys)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings