### PR TITLE
Testing branch

### DIFF
--- a/ocf_data_sampler/numpy_sample/datetime_features.py
+++ b/ocf_data_sampler/numpy_sample/datetime_features.py
@@ -22,7 +22,7 @@ def _get_date_time_in_pi(
     return date_in_pi, time_in_pi
 
 
-def make_datetime_numpy_dict(datetimes: pd.DatetimeIndex, key_prefix: str = "wind") -> dict:
+def make_datetime_numpy_dict(datetimes: pd.DatetimeIndex) -> dict:
     """ Make dictionary of datetime features"""
 
     if datetimes.empty:
@@ -33,14 +33,9 @@ def make_datetime_numpy_dict(datetimes: pd.DatetimeIndex, key_prefix: str = "win
     date_in_pi, time_in_pi = _get_date_time_in_pi(datetimes)
 
     # Store
-    date_sin_batch_key = key_prefix + "_date_sin"
-    date_cos_batch_key = key_prefix + "_date_cos"
-    time_sin_batch_key = key_prefix + "_time_sin"
-    time_cos_batch_key = key_prefix + "_time_cos"
-
-    time_numpy_sample[date_sin_batch_key] = np.sin(date_in_pi)
-    time_numpy_sample[date_cos_batch_key] = np.cos(date_in_pi)
-    time_numpy_sample[time_sin_batch_key] = np.sin(time_in_pi)
-    time_numpy_sample[time_cos_batch_key] = np.cos(time_in_pi)
+    time_numpy_sample["date_sin"] = np.sin(date_in_pi)
+    time_numpy_sample["date_cos"] = np.cos(date_in_pi)
+    time_numpy_sample["time_sin"] = np.sin(time_in_pi)
+    time_numpy_sample["time_cos"] = np.cos(time_in_pi)
 
     return time_numpy_sample

--- a/ocf_data_sampler/torch_datasets/datasets/site.py
+++ b/ocf_data_sampler/torch_datasets/datasets/site.py
@@ -241,7 +241,7 @@ class SitesDataset(Dataset):
 
         # add datetime features
         datetimes = pd.DatetimeIndex(combined_sample_dataset.site__time_utc.values)
-        datetime_features = make_datetime_numpy_dict(datetimes=datetimes, key_prefix="site_")
+        datetime_features = make_datetime_numpy_dict(datetimes=datetimes)
         combined_sample_dataset = combined_sample_dataset.assign_coords(
             {k: ("site__time_utc", v) for k, v in datetime_features.items()}
         )

--- a/tests/numpy_sample/test_datetime_features.py
+++ b/tests/numpy_sample/test_datetime_features.py
@@ -15,26 +15,18 @@ def test_calculate_azimuth_and_elevation():
 
     assert len(datetime_features) == 4
 
-    assert len(datetime_features["wind_date_sin"]) == len(datetimes)
-    assert (datetime_features["wind_date_cos"] != datetime_features["wind_date_sin"]).all()
+    assert len(datetime_features["date_sin"]) == len(datetimes)
+    assert (datetime_features["date_cos"] != datetime_features["date_sin"]).all()
 
     # assert all values are between -1 and 1
-    assert all(np.abs(datetime_features["wind_date_sin"]) <= 1)
-    assert all(np.abs(datetime_features["wind_date_cos"]) <= 1)
-    assert all(np.abs(datetime_features["wind_time_sin"]) <= 1)
-    assert all(np.abs(datetime_features["wind_time_cos"]) <= 1)
+    assert all(np.abs(datetime_features["date_sin"]) <= 1)
+    assert all(np.abs(datetime_features["date_cos"]) <= 1)
+    assert all(np.abs(datetime_features["time_sin"]) <= 1)
+    assert all(np.abs(datetime_features["time_cos"]) <= 1)
 
 
-def test_make_datetime_numpy_batch_custom_key_prefix():
-    # Test function correctly applies custom prefix to dict keys
-    datetimes = pd.to_datetime(["2024-06-20 12:00", "2024-06-20 12:30", "2024-06-20 13:00"])
-    key_prefix = "solar"
+# removed the test_make_datetime_numpy_batch_custom_key_prefix function
 
-    datetime_features = make_datetime_numpy_dict(datetimes, key_prefix=key_prefix)
-
-    # Assert dict contains expected quantity of keys and verify starting with custom prefix
-    assert len(datetime_features) == 4
-    assert all(key.startswith(key_prefix) for key in datetime_features.keys())
 
 
 def test_make_datetime_numpy_batch_empty_input():


### PR DESCRIPTION
# Pull Request

## Description

This PR removes the unnecessary key_prefix from time-related features in make_datetime_numpy_dict, which was previously required for ocf_datapipes


##Fixes 
#162 Removed key_prefix from time features and deleted unnecessary function.


## How Has This Been Tested?

#Run pytest to ensure all tests.
#there is an issue with compatibility with Pydantic v2 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
