### PR TITLE
Issue/gsp

### DIFF
--- a/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
+++ b/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
@@ -84,16 +84,6 @@ def process_and_combine_datasets(
             )
         )
 
-        # Add coordinate data
-        # TODO: Do we need all of these?
-        numpy_modalities.append(
-            {
-                GSPSampleKey.gsp_id: location.id,
-                GSPSampleKey.x_osgb: location.x,
-                GSPSampleKey.y_osgb: location.y,
-            }
-        )
-
     if target_key == 'gsp':
         # Make sun coords NumpySample
         datetimes = pd.date_range(
@@ -103,6 +93,14 @@ def process_and_combine_datasets(
         )
 
         lon, lat = osgb_to_lon_lat(location.x, location.y)
+
+        numpy_modalities.append(
+            {
+                GSPSampleKey.gsp_id: location.id,
+                GSPSampleKey.x_osgb: location.x,
+                GSPSampleKey.y_osgb: location.y,
+            }
+        )
 
     numpy_modalities.append(
         make_sun_position_numpy_sample(datetimes, lon, lat, key_prefix=target_key)

--- a/tests/torch_datasets/test_pvnet_uk.py
+++ b/tests/torch_datasets/test_pvnet_uk.py
@@ -55,6 +55,7 @@ def test_process_and_combine_datasets(pvnet_config_filename):
     assert "nwp" in sample
     assert sample["satellite_actual"].shape == (7, 1, 2, 2)
     assert sample["nwp"]["ukv"]["nwp"].shape == (4, 1, 2, 2)
+    assert "gsp_id" in sample
 
 
 def test_compute():


### PR DESCRIPTION
# Pull Request

## Description

The current keys are
`['nwp', 'satellite_actual', 'satellite_time_utc', 'satellite_x_geostationary', 'satellite_y_geostationary', 'gsp_solar_azimuth', 'gsp_solar_elevation']`

This PR adds `gsp_id` to sample

We need this for production, to makes sure we know what sample is from which gsp_id as sometimes the dataloader shuffle things, and/or we want to keep track of it
I thought we also need this in ML, for embedding, but perhaps we havent done that for a while

This helps https://github.com/openclimatefix/uk-pvnet-app/pull/180

## How Has This Been Tested?

- [x] CI tests
- [x] added a test


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
