### PR TITLE
chore(root): Remove uneeded MANIFEST file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include *.txt
-include ocf_data_sampler/data/*


### PR DESCRIPTION
Removes manifest file. [This line](https://github.com/openclimatefix/ocf-data-sampler/blob/3054a5721ba2897ec76841bba97ac4c7d0e34d2c/pyproject.toml#L59) in pyproject.toml supercedes it, specifying to setuptools to include CSV files in the package.