### PR TITLE
fix: attribute checking

### DIFF
--- a/ocf_data_sampler/torch_datasets/utils/validate_channels.py
+++ b/ocf_data_sampler/torch_datasets/utils/validate_channels.py
@@ -52,7 +52,9 @@ def validate_nwp_channels(config: Configuration) -> None:
         ValueError: If there's a mismatch between configured NWP channels
         and normalisation constants
     """
-    if hasattr(config.input_data, "nwp") and (config.input_data.nwp is not None):
+    if hasattr(config.input_data, "nwp") and (
+        config.input_data.nwp is not None
+        ):
         for _, nwp_config in config.input_data.nwp.items():
             provider = nwp_config.provider
             validate_channels(
@@ -73,7 +75,9 @@ def validate_satellite_channels(config: Configuration) -> None:
         ValueError: If there's a mismatch between configured satellite channels
         and normalisation constants
     """
-    if hasattr(config.input_data, "satellite") and (config.input_data.satellite is not None):
+    if hasattr(config.input_data, "satellite") and (
+        config.input_data.satellite is not None
+        ):
         validate_channels(
             data_channels=config.input_data.satellite.channels,
             means_channels=RSS_MEAN.channel.values,

--- a/ocf_data_sampler/torch_datasets/utils/validate_channels.py
+++ b/ocf_data_sampler/torch_datasets/utils/validate_channels.py
@@ -52,7 +52,7 @@ def validate_nwp_channels(config: Configuration) -> None:
         ValueError: If there's a mismatch between configured NWP channels
         and normalisation constants
     """
-    if hasattr(config.input_data, "nwp"):
+    if hasattr(config.input_data, "nwp") and (config.input_data.nwp is not None):
         for _, nwp_config in config.input_data.nwp.items():
             provider = nwp_config.provider
             validate_channels(
@@ -73,7 +73,7 @@ def validate_satellite_channels(config: Configuration) -> None:
         ValueError: If there's a mismatch between configured satellite channels
         and normalisation constants
     """
-    if hasattr(config.input_data, "satellite"):
+    if hasattr(config.input_data, "satellite") and (config.input_data.satellite is not None):
         validate_channels(
             data_channels=config.input_data.satellite.channels,
             means_channels=RSS_MEAN.channel.values,


### PR DESCRIPTION
### **Pull Request: Fix for PVNetUKRegionalDataset Configuration Validation Error (#196)**  

#### **Description**  
This PR fixes an issue with `PVNetUKRegionalDataset` where the configuration validation fails due to missing satellite channel attributes in the config file. The root cause was the absence of the `satellite` key in `input_data`, which led to an `AttributeError` when attempting to access `config.input_data.satellite.channels`.  

**Fixes #196**  

#### **Changes Made**  
Added check during validation 
```python
(config.input_data.satellite is not None) 
```
and 
```python
(config.input_data.nwp is not None) 
```

#### **How Has This Been Tested?**  
- Verified that the provided `config.yaml` is read properly.  


#### **Checklist:**  
- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
