### PR TITLE
GFS Data Support in ocf-data-sampler

### DIFF
--- a/ocf_data_sampler/load/nwp/nwp.py
+++ b/ocf_data_sampler/load/nwp/nwp.py
@@ -5,7 +5,7 @@ import xarray as xr
 from ocf_data_sampler.load.nwp.providers.ecmwf import open_ifs
 from ocf_data_sampler.load.nwp.providers.icon import open_icon_eu
 from ocf_data_sampler.load.nwp.providers.ukv import open_ukv
-
+from ocf_data_sampler.load.nwp.providers.gfs import open_gfs  # Import GFS provider
 
 def open_nwp(zarr_path: str | list[str], provider: str) -> xr.DataArray:
     """Opens NWP zarr.
@@ -13,13 +13,21 @@ def open_nwp(zarr_path: str | list[str], provider: str) -> xr.DataArray:
     Args:
         zarr_path: path to the zarr file
         provider: NWP provider
+
+    Returns:
+        Xarray DataArray of the NWP data
     """
-    if provider.lower() == "ukv":
+    provider = provider.lower()
+
+    if provider == "ukv":
         _open_nwp = open_ukv
-    elif provider.lower() == "ecmwf":
+    elif provider == "ecmwf":
         _open_nwp = open_ifs
-    elif provider.lower() == "icon-eu":
+    elif provider == "icon-eu":
         _open_nwp = open_icon_eu
+    elif provider == "gfs": 
+        _open_nwp = open_gfs
     else:
         raise ValueError(f"Unknown provider: {provider}")
+
     return _open_nwp(zarr_path)

--- a/ocf_data_sampler/load/nwp/providers/gfs.py
+++ b/ocf_data_sampler/load/nwp/providers/gfs.py
@@ -1,0 +1,32 @@
+"""Open GFS Forecast data"""
+
+import logging
+import xarray as xr
+from ocf_data_sampler.load.nwp.providers.utils import open_zarr_paths
+_log = logging.getLogger(__name__)
+
+
+def open_gfs(zarr_path) -> xr.DataArray:
+    """
+    Opens the GFS data
+
+    Args:
+        zarr_path: Path to the zarr to open
+
+    Returns:
+        Xarray DataArray of the NWP data
+    """
+    _log.info("Loading NWP GFS data")
+
+    # Open data
+    gfs: xr.Dataset = open_zarr_paths(zarr_path, time_dim="init_time_utc")
+    nwp: xr.DataArray = gfs.to_array()
+
+    del gfs
+
+    nwp = nwp.rename({"variable": "channel"})
+    if "init_time" in nwp.dims:
+        nwp = nwp.rename({"init_time": "init_time_utc"})
+    nwp = nwp.transpose("init_time_utc", "step", "channel", "latitude", "longitude")
+
+    return nwp


### PR DESCRIPTION
##  Description

This PR adds support for **GFS (Global Forecast System) data** in `ocf-data-sampler`. Previously, `GFS` was not recognized as a valid provider, causing a `ValueError: Unknown provider: gfs`. This change introduces:
- A new **GFS data loader** (`gfs.py`) under `ocf_data_sampler/load/nwp/providers/`.
- Modifications to **nwp.py** to recognize `"gfs"` as a valid provider and use `open_gfs`.
- Ensured compatibility with the existing structure of `ocf-data-sampler`.

**Fixes**: #188


## **Checklist**
- [x] My code follows [[OCF’s coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)](https://github.com/openclimatefix/.github/blob/main/coding_style.md).
- [x] I have performed a self-review of my own code.
- [ ] I have updated the documentation if necessary.
- [ ] I have added tests to ensure functionality works as expected.
- [x] I have checked my code and corrected any misspellings.

---

This PR is now ready for review! 🚀 Let me know if you need any refinements before submitting.