### PR TITLE
Swapped latitude and longitude in the transpose function to follow st…

### DIFF
--- a/ocf_data_sampler/load/nwp/providers/gfs.py
+++ b/ocf_data_sampler/load/nwp/providers/gfs.py
@@ -31,6 +31,6 @@ def open_gfs(zarr_path: str | list[str]) -> xr.DataArray:
     check_time_unique_increasing(nwp.init_time_utc)
     nwp = make_spatial_coords_increasing(nwp, x_coord="longitude", y_coord="latitude")
 
-    nwp = nwp.transpose("init_time_utc", "step", "channel", "latitude", "longitude")
+    nwp = nwp.transpose("init_time_utc", "step", "channel", "longitude", "latitude")
 
     return nwp

--- a/ocf_data_sampler/load/nwp/providers/icon.py
+++ b/ocf_data_sampler/load/nwp/providers/icon.py
@@ -41,6 +41,6 @@ def open_icon_eu(zarr_path: str) -> xr.Dataset:
     nwp = nwp.isel(step=slice(0, 78))
     nwp = remove_isobaric_lelvels_from_coords(nwp)
     nwp = nwp.to_array().rename({"variable": "channel"})
-    nwp = nwp.transpose("init_time_utc", "step", "channel", "latitude", "longitude")
+    nwp = nwp.transpose("init_time_utc", "step", "channel", "longitude", "latitude")
     nwp = make_spatial_coords_increasing(nwp, x_coord="longitude", y_coord="latitude")
     return nwp


### PR DESCRIPTION
…andard practice for spatial coords

# Pull Request

## Description

The parameters within the transpose function put latitude first which broke our ordering conventions. Just changed the parameters to prioritize longitude first
Fixes #

## How Has This Been Tested?
- Not entirely sure how to test run a .zarr file and validate the open_icon_eu function, however, I don't think there should be any errors as I just switched the transpose function to follow the same consistent parameters such as in ecmwf.py. 


- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X ] I have performed a self-review of my own code
- [ X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X] I have checked my code and corrected any misspellings
