### PR TITLE
Downstream update for `dropout_timedeltas_minutes` in config changing from `None`-> `[]` for null value

### DIFF
--- a/ocf_data_sampler/select/select_time_slice.py
+++ b/ocf_data_sampler/select/select_time_slice.py
@@ -55,7 +55,10 @@ def select_time_slice_nwp(
     if accum_channels is None:
         accum_channels = []
 
-    if dropout_timedeltas is not None:
+    if dropout_timedeltas is None:
+        dropout_timedeltas = []
+
+    if len(dropout_timedeltas)>0:
         if not all(t < pd.Timedelta(0) for t in dropout_timedeltas):
             raise ValueError("dropout timedeltas must be negative")
         if len(dropout_timedeltas) < 1:
@@ -64,7 +67,7 @@ def select_time_slice_nwp(
     if not (0 <= dropout_frac <= 1):
         raise ValueError("dropout_frac must be between 0 and 1")
 
-    consider_dropout = (dropout_timedeltas is not None) and dropout_frac > 0
+    consider_dropout = len(dropout_timedeltas) > 0 and dropout_frac > 0
 
     # The accumatated and non-accumulated channels
     accum_channels = np.intersect1d(da.channel.values, accum_channels)

--- a/ocf_data_sampler/torch_datasets/utils/valid_time_periods.py
+++ b/ocf_data_sampler/torch_datasets/utils/valid_time_periods.py
@@ -28,7 +28,7 @@ def find_valid_time_periods(datasets_dict: dict, config: Configuration) -> pd.Da
         for nwp_key, nwp_config in config.input_data.nwp.items():
             da = datasets_dict["nwp"][nwp_key]
 
-            if nwp_config.dropout_timedeltas_minutes is None:
+            if nwp_config.dropout_timedeltas_minutes==[]:
                 max_dropout = minutes(0)
             else:
                 max_dropout = minutes(np.max(np.abs(nwp_config.dropout_timedeltas_minutes)))


### PR DESCRIPTION
# Pull Request

## Description

Recently in one of the mob programming sessions we [updated the config model ](https://github.com/openclimatefix/ocf-data-sampler/pull/183/files#diff-7d8af53f8ccb0fe5ee493bd54771546ce767703b9d7ea18f09d70e1041563ae2) to update the null value of `dropout_timedeltas_minutes` from `None` to an empty list. This has broken some downstream code which still expects the null value of the list to be `None`.

This PR allows the functions where `dropout_timedeltas_minutes` is passed in to run with an empty list

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
