### PR TITLE
Make coords contiguous if reversed in loading

### DIFF
--- a/ocf_data_sampler/load/utils.py
+++ b/ocf_data_sampler/load/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for working with xarray objects."""
 
+import numpy as np
 import pandas as pd
 import xarray as xr
 
@@ -22,8 +23,10 @@ def make_spatial_coords_increasing(ds: xr.Dataset, x_coord: str, y_coord: str) -
     # Make sure the coords are in increasing order
     if ds[x_coord][0] > ds[x_coord][-1]:
         ds = ds.isel({x_coord: slice(None, None, -1)})
+        ds[x_coord] = np.ascontiguousarray(ds[x_coord].values)
     if ds[y_coord][0] > ds[y_coord][-1]:
         ds = ds.isel({y_coord: slice(None, None, -1)})
+        ds[y_coord] = np.ascontiguousarray(ds[y_coord].values)
 
     # Check the coords are all increasing now
     if not (ds[x_coord].diff(dim=x_coord) > 0).all():

--- a/ocf_data_sampler/load/utils.py
+++ b/ocf_data_sampler/load/utils.py
@@ -23,6 +23,8 @@ def make_spatial_coords_increasing(ds: xr.Dataset, x_coord: str, y_coord: str) -
     # Make sure the coords are in increasing order
     if ds[x_coord][0] > ds[x_coord][-1]:
         ds = ds.isel({x_coord: slice(None, None, -1)})
+        # Below we the coord values so we don't have numpy array with negative strides
+        # Numpy arrays with negative strides cannot be converted to torch Tensor
         ds[x_coord] = np.ascontiguousarray(ds[x_coord].values)
     if ds[y_coord][0] > ds[y_coord][-1]:
         ds = ds.isel({y_coord: slice(None, None, -1)})


### PR DESCRIPTION
# Pull Request

## Description

This PR is a proposal to fix issue #211. See the issue for full details

Fixes #

## How Has This Been Tested?

I have run this locally to create samples which are converted straight to torch tensors without being saved first

I have made sure the samples created by the UK PVNet sampler all the numpy arrays in the numpy batch have positive strides

Also this is a minimal example showing that the fix works:

```
import xarray as xr
import numpy as np
import dask

# Create a DataArray with a single dimension 'x'. The x coord is in decreading order: [9,8,7,...,1,0]
x_coords = np.arange(9, -1, -1)

# The underlying data is lazy - values [9,8,7,...,1,0]
values = dask.array.arange(9, -1, -1)

da = xr.DataArray(values, dims=['x'], coords={'x': x_coords}, name='example_data')

# Reverse the data in the x dimension
da = da.isel(x=slice(None, None, -1))

# Print the strides - x has a negative stride but the data has a positive stride
print("x-strides", da.x.data.strides)  # >> x-strides (-8,)
print("data-stride", da.values.strides)  # >> data-stride (8,)

# Make the x coord array contiguous
da["x"] = np.ascontiguousarray(da.x.values)

# Print the strides - both the data and the x coord have positive strides
print("x-strides", da.x.data.strides)  # >> x-strides (8,)
print("data-stride", da.values.strides)  # >> data-stride (8,)

# Sanity check to make sure we haven't muddled up the data and its coords somehow
for i in range(10):
    assert da.sel(x=i)==i
    assert da.isel(x=i)==i
```

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
