### PR TITLE
dim order corrected

### DIFF
--- a/ocf_data_sampler/load/nwp/providers/gfs.py
+++ b/ocf_data_sampler/load/nwp/providers/gfs.py
@@ -31,6 +31,6 @@ def open_gfs(zarr_path: str | list[str]) -> xr.DataArray:
     check_time_unique_increasing(nwp.init_time_utc)
     nwp = make_spatial_coords_increasing(nwp, x_coord="longitude", y_coord="latitude")
 
-    nwp = nwp.transpose("init_time_utc", "step", "channel", "latitude", "longitude")
+    nwp = nwp.transpose("init_time_utc", "step", "channel", "longitude", "latitude")
 
     return nwp

--- a/ocf_data_sampler/load/nwp/providers/icon.py
+++ b/ocf_data_sampler/load/nwp/providers/icon.py
@@ -41,6 +41,6 @@ def open_icon_eu(zarr_path: str) -> xr.Dataset:
     nwp = nwp.isel(step=slice(0, 78))
     nwp = remove_isobaric_lelvels_from_coords(nwp)
     nwp = nwp.to_array().rename({"variable": "channel"})
-    nwp = nwp.transpose("init_time_utc", "step", "channel", "latitude", "longitude")
+    nwp = nwp.transpose("init_time_utc", "step", "channel", "longitude", "latitude")
     nwp = make_spatial_coords_increasing(nwp, x_coord="longitude", y_coord="latitude")
     return nwp


### PR DESCRIPTION
# Pull Request

## Description

This PR corrects the dimension ordering in the ICON EU data loader, ensuring consistency with the standard practice of having spatial coordinates ordered as (..., x, y)—i.e., (..., longitude, latitude).

Fixes #

Corrected transpose dimension ordering from incorrect (latitude, longitude) to correct (longitude, latitude) in both gfs.py and icon.py files.


## How Has This Been Tested?

-Verified dimension order explicitly (print(nwp.dims)).
-Loaded ICON EU data locally to confirm correct dimensional ordering (init_time_utc, step, channel, longitude, latitude).
-Conducted a visual sanity check using matplotlib plotting to ensure spatial orientation is correct.

- [ ] Yes

Sanity Check:
-Performed quick visual inspection (plotting sample data slices) to ensure dimensions (longitude, latitude) are correctly represented spatially.


- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
