### PR TITLE
Set param for incoming deprecation

### DIFF
--- a/ocf_data_sampler/load/nwp/providers/utils.py
+++ b/ocf_data_sampler/load/nwp/providers/utils.py
@@ -20,6 +20,7 @@ def open_zarr_paths(zarr_path: str | list[str], time_dim: str = "init_time") -> 
             concat_dim=time_dim,
             combine="nested",
             chunks="auto",
+            decode_timedelta=True,
         ).sortby(time_dim)
     else:
         ds = xr.open_dataset(
@@ -28,5 +29,6 @@ def open_zarr_paths(zarr_path: str | list[str], time_dim: str = "init_time") -> 
             consolidated=True,
             mode="r",
             chunks="auto",
+            decode_timedelta=True,
         )
     return ds


### PR DESCRIPTION
# Pull Request

## Description

We are currently getting this warning when opening NWP datasets. The NWP datasets have a `step` dimension which is a timedelta wrt t0. 

```
FutureWarning: In a future version of xarray decode_timedelta will default to False rather than None. 
To silence this warning, set decode_timedelta to True, False, or a 'CFTimedeltaCoder' instance.
```

This PR fixes this warning
