### PR TITLE
patch dropout function for no dropout case

### DIFF
--- a/ocf_data_sampler/select/dropout.py
+++ b/ocf_data_sampler/select/dropout.py
@@ -33,7 +33,7 @@ def draw_dropout_time(
         raise ValueError("dropout_frac must be between 0 and 1 inclusive")
 
     if (len(dropout_timedeltas) == 0) or (np.random.uniform() >= dropout_frac):
-        dropout_time = t0
+        dropout_time = None
     else:
         dropout_time = t0 + np.random.choice(dropout_timedeltas)
 
@@ -42,7 +42,7 @@ def draw_dropout_time(
 
 def apply_dropout_time(
     ds: xr.DataArray,
-    dropout_time: pd.Timestamp,
+    dropout_time: pd.Timestamp | None,
 ) -> xr.DataArray:
     """Apply dropout time to the data.
 
@@ -50,5 +50,8 @@ def apply_dropout_time(
         ds: Xarray DataArray with 'time_utc' coordinate
         dropout_time: Time after which data is set to NaN
     """
-    # This replaces the times after the dropout with NaNs
-    return ds.where(ds.time_utc <= dropout_time)
+    if dropout_time is None:
+        return ds
+    else:
+        # This replaces the times after the dropout with NaNs
+        return ds.where(ds.time_utc <= dropout_time)

--- a/tests/select/test_dropout.py
+++ b/tests/select/test_dropout.py
@@ -52,11 +52,11 @@ def test_draw_dropout_time_none():
     # Dropout fraction is 0
     dropout_timedeltas = [pd.Timedelta(-30, "min")]
     dropout_time = draw_dropout_time(t0, dropout_timedeltas=dropout_timedeltas, dropout_frac=0)
-    assert dropout_time == t0
+    assert dropout_time == None
 
     # No dropout timedeltas and dropout fraction is 0
     dropout_time = draw_dropout_time(t0, dropout_timedeltas=[], dropout_frac=0)
-    assert dropout_time == t0
+    assert dropout_time == None
 
 
 @pytest.mark.parametrize("t0_str", ["12:00", "12:30", "13:00"])

--- a/tests/select/test_dropout.py
+++ b/tests/select/test_dropout.py
@@ -52,11 +52,11 @@ def test_draw_dropout_time_none():
     # Dropout fraction is 0
     dropout_timedeltas = [pd.Timedelta(-30, "min")]
     dropout_time = draw_dropout_time(t0, dropout_timedeltas=dropout_timedeltas, dropout_frac=0)
-    assert dropout_time == None
+    assert dropout_time is None
 
     # No dropout timedeltas and dropout fraction is 0
     dropout_time = draw_dropout_time(t0, dropout_timedeltas=[], dropout_frac=0)
-    assert dropout_time == None
+    assert dropout_time is None
 
 
 @pytest.mark.parametrize("t0_str", ["12:00", "12:30", "13:00"])


### PR DESCRIPTION
# Pull Request

## Description

The current dropout functionality was patched in a recent PR #183, this changed how the dropout_time was set when no dropout was specified in the configuration to return t0, instead of None. This introduced NaNs in times after t0 which isn't the intended outcome.

This has been fixed by reinstating the previous functionality, setting dropout_time to None where dropout is not desired, with ds being returned in the apply_dropout function if the dropout_time is None.

## How Has This Been Tested?

The existing test, `test_draw_dropout_time_none` has also been updated to reflect the None case.

- [X] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

I have inspected and printed the generation locally to track and verify the changes.

- [X] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
