### PR TITLE
Allow periods which start and end at the same timestamp

### DIFF
--- a/ocf_data_sampler/select/find_contiguous_time_periods.py
+++ b/ocf_data_sampler/select/find_contiguous_time_periods.py
@@ -247,15 +247,10 @@ def intersection_of_2_dataframes_of_periods(a: pd.DataFrame, b: pd.DataFrame) ->
         # Five ways in which two periods may overlap:
         # a: |----| or |---|   or  |---| or   |--|   or |-|
         # b:  |--|       |---|   |---|      |------|    |-|
-        # In all five, `a` must always start before `b` ends,
-        # and `a` must always end after `b` starts:
+        # In all five, `a` must always start before (or equal to) where `b` ends,
+        # and `a` must always end after (or equal to) where `b` starts.
 
-        # TODO: <= and >= because we should allow overlap time periods of length 1. e.g.
-        # a: |----|      or   |---|
-        # b:      |--|            |---|
-        # These aren't allowed if we use < and >.
-
-        overlapping_periods = b[(a_period.start_dt < b.end_dt) & (a_period.end_dt > b.start_dt)]
+        overlapping_periods = b[(a_period.start_dt <= b.end_dt) & (a_period.end_dt >= b.start_dt)]
 
         # There are two ways in which two periods may *not* overlap:
         # a: |---|        or        |---|

--- a/tests/select/test_find_contiguous_time_periods.py
+++ b/tests/select/test_find_contiguous_time_periods.py
@@ -5,17 +5,16 @@ from ocf_data_sampler.select.find_contiguous_time_periods import (
     find_contiguous_t0_periods_nwp,
     intersection_of_2_dataframes_of_periods,
     intersection_of_multiple_dataframes_of_periods,
-    
 )
 
 
 def construct_time_periods_df(start_dts: list[str], end_dts: list[str]) -> pd.DataFrame:
     """Helper function to construct a DataFrame of time periods
-    
+
     Args:
         start_dts: List of period start datetimes
         end_dts: List of period end datetimes
-    
+
     Returns:
         pd.DataFrame: DataFrame with start and end datetimes columns where each period is a row
     """
@@ -43,7 +42,7 @@ def test_find_contiguous_t0_periods():
     )
 
     expected_results = construct_time_periods_df(
-        ["2023-01-01 13:35", "2023-01-01 15:35"], 
+        ["2023-01-01 13:35", "2023-01-01 15:35"],
         ["2023-01-01 14:10", "2023-01-01 16:45"],
     )
 

--- a/tests/select/test_find_contiguous_time_periods.py
+++ b/tests/select/test_find_contiguous_time_periods.py
@@ -105,7 +105,7 @@ def test_find_contiguous_t0_periods_nwp():
 def test_intersection_of_2_dataframes_of_periods():
 
     def assert_expected_result_with_reverse(a, b, expected_result):
-        """Asser that the calulated intersection is as expected with and without a and b switched"""
+        """Assert that the calulated intersection is as expected with and without a and b switched"""
         assert intersection_of_2_dataframes_of_periods(a, b).equals(expected_result)
         assert intersection_of_2_dataframes_of_periods(b, a).equals(expected_result)
 
@@ -113,8 +113,7 @@ def test_intersection_of_2_dataframes_of_periods():
     # b:  |--|
     a = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 12:00"])
     b = construct_time_periods_df(["2025-01-01 03:00"], ["2025-01-01 06:00"])
-    expected_result = construct_time_periods_df(["2025-01-01 03:00"], ["2025-01-01 06:00"])
-    assert_expected_result_with_reverse(a, b, expected_result)
+    assert_expected_result_with_reverse(a, b, expected_result=b)
 
     # a:   |----|
     # b: |--|
@@ -141,15 +140,13 @@ def test_intersection_of_2_dataframes_of_periods():
     # b:   |----|
     a = construct_time_periods_df(["2025-01-01 12:00"], ["2025-01-01 12:00"])
     b = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 18:00"])
-    expected_result = construct_time_periods_df(["2025-01-01 12:00"], ["2025-01-01 12:00"])
-    assert_expected_result_with_reverse(a, b, expected_result)
+    assert_expected_result_with_reverse(a, b, expected_result=a)
 
     # a:   |
     # b:   |----|
     a = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 00:00"])
     b = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 18:00"])
-    expected_result = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 00:00"])
-    assert_expected_result_with_reverse(a, b, expected_result)
+    assert_expected_result_with_reverse(a, b, expected_result=a)
 
     # a:   |
     # b:   |

--- a/tests/select/test_find_contiguous_time_periods.py
+++ b/tests/select/test_find_contiguous_time_periods.py
@@ -105,7 +105,7 @@ def test_find_contiguous_t0_periods_nwp():
 def test_intersection_of_2_dataframes_of_periods():
 
     def assert_expected_result_with_reverse(a, b, expected_result):
-        """Assert that the calulated intersection is as expected with and without a and b switched"""
+        """Assert the calulated intersection is as expected with and without a and b switched"""
         assert intersection_of_2_dataframes_of_periods(a, b).equals(expected_result)
         assert intersection_of_2_dataframes_of_periods(b, a).equals(expected_result)
 

--- a/tests/select/test_find_contiguous_time_periods.py
+++ b/tests/select/test_find_contiguous_time_periods.py
@@ -8,7 +8,7 @@ from ocf_data_sampler.select.find_contiguous_time_periods import (
 )
 
 
-def construct_time_periods_df(start_dts: list[str], end_dts: list[str]) -> pd.DataFrame:
+def construct_time_periods_df(start_dt: list[str], end_dt: list[str]) -> pd.DataFrame:
     """Helper function to construct a DataFrame of time periods
 
     Args:
@@ -20,8 +20,8 @@ def construct_time_periods_df(start_dts: list[str], end_dts: list[str]) -> pd.Da
     """
     return pd.DataFrame(
         {
-            "start_dt": pd.to_datetime(start_dts),
-            "end_dt": pd.to_datetime(end_dts),
+            "start_dt": pd.to_datetime(start_dt),
+            "end_dt": pd.to_datetime(end_dt),
         },
     )
 
@@ -42,37 +42,38 @@ def test_find_contiguous_t0_periods():
     )
 
     expected_results = construct_time_periods_df(
-        ["2023-01-01 13:35", "2023-01-01 15:35"],
-        ["2023-01-01 14:10", "2023-01-01 16:45"],
+        start_dt=["2023-01-01 13:35", "2023-01-01 15:35"],
+        end_dt = ["2023-01-01 14:10", "2023-01-01 16:45"],
     )
 
     assert periods.equals(expected_results)
 
 
 def test_find_contiguous_t0_periods_nwp():
+
     # These are the expected results of the test
-    expected_results = [
-        construct_time_periods_df(
-            ["2023-01-01 03:00", "2023-01-02 03:00"],
-            ["2023-01-01 21:00", "2023-01-03 06:00"],
-        ),
-        construct_time_periods_df(
-            ["2023-01-01 05:00", "2023-01-02 05:00"],
-            ["2023-01-01 21:00", "2023-01-03 06:00"],
-        ),
-        construct_time_periods_df(
-            ["2023-01-01 05:00", "2023-01-02 05:00", "2023-01-02 14:00"],
-            ["2023-01-01 18:00", "2023-01-02 09:00", "2023-01-03 03:00"],
-        ),
-        construct_time_periods_df(
-            ["2023-01-01 05:00", "2023-01-01 11:00",  "2023-01-02 05:00", "2023-01-02 14:00"],
-            ["2023-01-01 06:00", "2023-01-01 15:00", "2023-01-02 06:00",  "2023-01-03 00:00"],
-        ),
-        construct_time_periods_df(
-            ["2023-01-01 06:00", "2023-01-01 12:00", "2023-01-02 06:00", "2023-01-02 15:00"],
-            ["2023-01-01 09:00", "2023-01-01 18:00", "2023-01-02 09:00", "2023-01-03 03:00"],
-        ),
-    ]
+    exp_res1 = construct_time_periods_df(
+        start_dt=["2023-01-01 03:00", "2023-01-02 03:00"],
+        end_dt = ["2023-01-01 21:00", "2023-01-03 06:00"],
+    )
+    exp_res2 = construct_time_periods_df(
+        start_dt=["2023-01-01 05:00", "2023-01-02 05:00"],
+        end_dt = ["2023-01-01 21:00", "2023-01-03 06:00"],
+    )
+    exp_res3 = construct_time_periods_df(
+        start_dt=["2023-01-01 05:00", "2023-01-02 05:00", "2023-01-02 14:00"],
+        end_dt = ["2023-01-01 18:00", "2023-01-02 09:00", "2023-01-03 03:00"],
+    )
+    exp_res4 = construct_time_periods_df(
+        start_dt=["2023-01-01 05:00", "2023-01-01 11:00", "2023-01-02 05:00", "2023-01-02 14:00"],
+        end_dt = ["2023-01-01 06:00", "2023-01-01 15:00", "2023-01-02 06:00", "2023-01-03 00:00"],
+    )
+    exp_res5 = construct_time_periods_df(
+        start_dt=["2023-01-01 06:00", "2023-01-01 12:00", "2023-01-02 06:00", "2023-01-02 15:00"],
+        end_dt = ["2023-01-01 09:00", "2023-01-01 18:00", "2023-01-02 09:00", "2023-01-03 03:00"],
+    )
+
+    expected_results = [exp_res1, exp_res2, exp_res3, exp_res4, exp_res5]
 
     # Create 3-hourly init times with a few time stamps missing
     freq = pd.Timedelta(3, "h")
@@ -111,80 +112,78 @@ def test_intersection_of_2_dataframes_of_periods():
 
     # a: |----|
     # b:  |--|
-    a = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 12:00"])
-    b = construct_time_periods_df(["2025-01-01 03:00"], ["2025-01-01 06:00"])
+    a = construct_time_periods_df(start_dt=["2025-01-01 00:00"], end_dt=["2025-01-01 12:00"])
+    b = construct_time_periods_df(start_dt=["2025-01-01 03:00"], end_dt=["2025-01-01 06:00"])
     assert_expected_result_with_reverse(a, b, expected_result=b)
 
     # a:   |----|
     # b: |--|
-    a = construct_time_periods_df(["2025-01-01 12:00"], ["2025-01-01 18:00"])
-    b = construct_time_periods_df(["2025-01-01 03:00"], ["2025-01-01 15:00"])
-    expected_result = construct_time_periods_df(["2025-01-01 12:00"], ["2025-01-01 15:00"])
-    assert_expected_result_with_reverse(a, b, expected_result)
+    a = construct_time_periods_df(start_dt=["2025-01-01 12:00"], end_dt=["2025-01-01 18:00"])
+    b = construct_time_periods_df(start_dt=["2025-01-01 03:00"], end_dt=["2025-01-01 15:00"])
+    exp_res = construct_time_periods_df(start_dt=["2025-01-01 12:00"], end_dt=["2025-01-01 15:00"])
+    assert_expected_result_with_reverse(a, b, expected_result=exp_res)
 
     # a:      |--|
     # b:   |--|
-    a = construct_time_periods_df(["2025-01-01 12:00"], ["2025-01-01 18:00"])
-    b = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 12:00"])
-    expected_result = construct_time_periods_df(["2025-01-01 12:00"], ["2025-01-01 12:00"])
-    assert_expected_result_with_reverse(a, b, expected_result)
+    a = construct_time_periods_df(start_dt=["2025-01-01 12:00"], end_dt=["2025-01-01 18:00"])
+    b = construct_time_periods_df(start_dt=["2025-01-01 00:00"], end_dt=["2025-01-01 12:00"])
+    exp_res = construct_time_periods_df(start_dt=["2025-01-01 12:00"], end_dt=["2025-01-01 12:00"])
+    assert_expected_result_with_reverse(a, b, expected_result=exp_res)
 
     # a:      |
     # b:   |--|
-    a = construct_time_periods_df(["2025-01-01 12:00"], ["2025-01-01 12:00"])
-    b = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 12:00"])
-    expected_result = construct_time_periods_df(["2025-01-01 12:00"], ["2025-01-01 12:00"])
-    assert_expected_result_with_reverse(a, b, expected_result)
+    a = construct_time_periods_df(start_dt=["2025-01-01 12:00"], end_dt=["2025-01-01 12:00"])
+    b = construct_time_periods_df(start_dt=["2025-01-01 00:00"], end_dt=["2025-01-01 12:00"])
+    exp_res = construct_time_periods_df(start_dt=["2025-01-01 12:00"], end_dt=["2025-01-01 12:00"])
+    assert_expected_result_with_reverse(a, b, expected_result=exp_res)
 
     # a:      |
     # b:   |----|
-    a = construct_time_periods_df(["2025-01-01 12:00"], ["2025-01-01 12:00"])
-    b = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 18:00"])
+    a = construct_time_periods_df(start_dt=["2025-01-01 12:00"], end_dt=["2025-01-01 12:00"])
+    b = construct_time_periods_df(start_dt=["2025-01-01 00:00"], end_dt=["2025-01-01 18:00"])
     assert_expected_result_with_reverse(a, b, expected_result=a)
 
     # a:   |
     # b:   |----|
-    a = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 00:00"])
-    b = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 18:00"])
+    a = construct_time_periods_df(start_dt=["2025-01-01 00:00"], end_dt=["2025-01-01 00:00"])
+    b = construct_time_periods_df(start_dt=["2025-01-01 00:00"], end_dt=["2025-01-01 18:00"])
     assert_expected_result_with_reverse(a, b, expected_result=a)
 
     # a:   |
     # b:   |
-    a = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 00:00"])
+    a = construct_time_periods_df(start_dt=["2025-01-01 00:00"], end_dt=["2025-01-01 00:00"])
     assert_expected_result_with_reverse(a=a, b=a, expected_result=a)
 
     # a:     |
     # b:   |
-    a = construct_time_periods_df(["2025-01-01 00:00"], ["2025-01-01 00:00"])
-    b = construct_time_periods_df(["2025-01-01 06:00"], ["2025-01-01 06:00"])
-    expected_result = construct_time_periods_df([], []) # no intersection
-    assert_expected_result_with_reverse(a, b, expected_result)
+    a = construct_time_periods_df(start_dt=["2025-01-01 00:00"], end_dt=["2025-01-01 00:00"])
+    b = construct_time_periods_df(start_dt=["2025-01-01 06:00"], end_dt=["2025-01-01 06:00"])
+    exp_res = construct_time_periods_df([], []) # no intersection
+    assert_expected_result_with_reverse(a, b, expected_result=exp_res)
 
 
 def test_intersection_of_multiple_dataframes_of_periods():
     periods_1 = construct_time_periods_df(
-        ["2023-01-01 05:00", "2023-01-01 14:10"],
-        ["2023-01-01 13:35", "2023-01-01 18:00"],
+        start_dt=["2023-01-01 05:00", "2023-01-01 14:10"],
+        end_dt = ["2023-01-01 13:35", "2023-01-01 18:00"],
     )
 
     periods_2 = construct_time_periods_df(
-        ["2023-01-01 12:00"],
-        ["2023-01-02 00:00"],
+        start_dt=["2023-01-01 12:00"],
+        end_dt = ["2023-01-02 00:00"],
     )
 
     periods_3 = construct_time_periods_df(
-        ["2023-01-01 00:00", "2023-01-01 13:00"],
-        ["2023-01-01 12:30", "2023-01-01 23:00"],
+        start_dt=["2023-01-01 00:00", "2023-01-01 13:00"],
+        end_dt = ["2023-01-01 12:30", "2023-01-01 23:00"],
     )
 
     expected_result = construct_time_periods_df(
-        ["2023-01-01 12:00", "2023-01-01 13:00", "2023-01-01 14:10"],
-        ["2023-01-01 12:30", "2023-01-01 13:35", "2023-01-01 18:00"],
+        start_dt=["2023-01-01 12:00", "2023-01-01 13:00", "2023-01-01 14:10"],
+        end_dt = ["2023-01-01 12:30", "2023-01-01 13:35", "2023-01-01 18:00"],
     )
 
-    overlaping_periods = intersection_of_multiple_dataframes_of_periods(
-        [periods_1, periods_2, periods_3],
-    )
+    result = intersection_of_multiple_dataframes_of_periods([periods_1, periods_2, periods_3])
 
     # Check if results are as expected
-    assert overlaping_periods.equals(expected_result)
+    assert result.equals(expected_result)


### PR DESCRIPTION
# Pull Request

## Description

Updates `intersection_of_2_dataframes_of_periods()` for the edge cases in the TODO section

i.e. intersections like these now have the expected overlaps

```
a: |----|
b:      |---|
>>      |


a:   |
b:   |---|
>>   |
```

Also added tests for these cases (and other untested cases) and added a utility function to the test module to simplify some out our testing code for this module


This partly solves (though not fully) #192


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
