### PR TITLE
Validate samples after load

### DIFF
--- a/ocf_data_sampler/config/model.py
+++ b/ocf_data_sampler/config/model.py
@@ -320,17 +320,16 @@ class Configuration(Base):
     general: General = General()
     input_data: InputData = InputData()
     expected_shapes: dict = Field(default_factory=dict)
-    
+
     def get_expected_shapes(self) -> dict:
-        """
-        Returns dictionary of expected shapes based on configuration.
-        
+        """Returns dictionary of expected shapes based on configuration.
+
         This combines explicitly defined expected_shapes with those
         calculated from input_data configuration.
         """
         result = {}
-        
+
         if self.expected_shapes:
             result.update(self.expected_shapes)
-            
+
         return result

--- a/ocf_data_sampler/config/model.py
+++ b/ocf_data_sampler/config/model.py
@@ -319,4 +319,3 @@ class Configuration(Base):
 
     general: General = General()
     input_data: InputData = InputData()
-    expected_shapes: dict = Field(default_factory=dict)

--- a/ocf_data_sampler/config/model.py
+++ b/ocf_data_sampler/config/model.py
@@ -319,3 +319,18 @@ class Configuration(Base):
 
     general: General = General()
     input_data: InputData = InputData()
+    expected_shapes: dict = Field(default_factory=dict)
+    
+    def get_expected_shapes(self) -> dict:
+        """
+        Returns dictionary of expected shapes based on configuration.
+        
+        This combines explicitly defined expected_shapes with those
+        calculated from input_data configuration.
+        """
+        result = {}
+        
+        if self.expected_shapes:
+            result.update(self.expected_shapes)
+            
+        return result

--- a/ocf_data_sampler/config/model.py
+++ b/ocf_data_sampler/config/model.py
@@ -320,16 +320,3 @@ class Configuration(Base):
     general: General = General()
     input_data: InputData = InputData()
     expected_shapes: dict = Field(default_factory=dict)
-
-    def get_expected_shapes(self) -> dict:
-        """Returns dictionary of expected shapes based on configuration.
-
-        This combines explicitly defined expected_shapes with those
-        calculated from input_data configuration.
-        """
-        result = {}
-
-        if self.expected_shapes:
-            result.update(self.expected_shapes)
-
-        return result

--- a/ocf_data_sampler/torch_datasets/sample/uk_regional.py
+++ b/ocf_data_sampler/torch_datasets/sample/uk_regional.py
@@ -121,8 +121,9 @@ class UKRegionalSample(SampleBase):
                     f"Satellite data ('{sat_key}') should have at least 2 dimensions, "
                     f"got shape {sat_data.shape}",
                 )
-            actual_spatial_dims = sat_data.shape[-2:]
-            expected_spatial_dims = expected_shapes[sat_key][-2:]
+
+            actual_spatial_dims = sat_data.shape
+            expected_spatial_dims = expected_shapes[sat_key]
 
             check_dimensions(
                 actual_shape=tuple(actual_spatial_dims),

--- a/ocf_data_sampler/torch_datasets/sample/uk_regional.py
+++ b/ocf_data_sampler/torch_datasets/sample/uk_regional.py
@@ -1,11 +1,9 @@
 """PVNet UK Regional sample implementation for dataset handling and visualisation."""
 
-import logging
 
 import torch
 from typing_extensions import override
 
-from ocf_data_sampler.config.load import load_yaml_configuration
 from ocf_data_sampler.numpy_sample import (
     GSPSampleKey,
     NWPSampleKey,
@@ -229,49 +227,3 @@ class UKRegionalSample(SampleBase):
 
         plt.tight_layout()
         plt.show()
-
-
-def validate_samples(
-    samples: list[UKRegionalSample],
-    config_or_path: dict[str, object] | str | None = None,
-) -> dict[str, object]:
-    """Validates a collection of UKRegionalSample objects.
-
-    Args:
-        samples: List of UKRegionalSample objects
-        config_or_path: Either a configuration dictionary or path to a validation config file
-
-    Returns:
-        dict: Summary of validation results
-    """
-    # Determine if path or already a config dict
-    config = None
-    if config_or_path is not None:
-        if isinstance(config_or_path, dict):
-            config = config_or_path
-        else:
-            try:
-                config_obj = load_yaml_configuration(config_or_path)
-                config = config_obj.dict()
-            except Exception as e:
-                logging.warning(f"Failed to load config from {config_or_path}: {e}")
-
-    results = {
-        "total_samples": len(samples),
-        "valid_samples": 0,
-        "invalid_samples": 0,
-        "error_summary": {},
-    }
-
-    for i, sample in enumerate(samples):
-        validation = sample.validate_sample(config)
-        if validation["valid"]:
-            results["valid_samples"] += 1
-        else:
-            results["invalid_samples"] += 1
-            for error in validation["errors"]:
-                if error not in results["error_summary"]:
-                    results["error_summary"][error] = []
-                results["error_summary"][error].append(i)
-
-    return results

--- a/ocf_data_sampler/torch_datasets/sample/uk_regional.py
+++ b/ocf_data_sampler/torch_datasets/sample/uk_regional.py
@@ -50,17 +50,17 @@ class UKRegionalSample(SampleBase):
         # TODO: We should move away from using torch.load(..., weights_only=False)
         return cls(torch.load(path, weights_only=False))
 
-    def validate_sample(self, config: Configuration) -> dict:
+    def validate_sample(self, config: Configuration) -> bool:
         """Validates that the sample has the expected structure and data shapes.
 
         Args:
             config: Configuration dict with expected shapes and required fields.
 
         Returns:
-            dict: Validation results with status and any validation errors.
+            bool: True if validation passes, otherwise raises an exception.
         """
-        if config is None:
-            raise ValueError("Configuration object is required for validation.")
+        if not isinstance(config, Configuration):
+            raise TypeError("config must be Configuration object")
 
         # Calculate expected shapes from configuration
         expected_shapes = calculate_expected_shapes(config)
@@ -122,12 +122,7 @@ class UKRegionalSample(SampleBase):
                 name="Satellite data",
             )
 
-        result = {
-            "status": "success",
-            "message": "Sample validated successfully with provided configuration.",
-        }
-
-        return result
+        return True
 
     @override
     def plot(self) -> None:

--- a/ocf_data_sampler/torch_datasets/sample/uk_regional.py
+++ b/ocf_data_sampler/torch_datasets/sample/uk_regional.py
@@ -50,12 +50,11 @@ class UKRegionalSample(SampleBase):
         # TODO: We should move away from using torch.load(..., weights_only=False)
         return cls(torch.load(path, weights_only=False))
 
-    def validate_sample(self, config: Configuration | None = None) -> dict:
+    def validate_sample(self, config: Configuration) -> dict:
         """Validates that the sample has the expected structure and data shapes.
 
         Args:
-            config: Optional configuration dict with expected shapes and required fields.
-                If None, uses default validation rules.
+            config: Configuration dict with expected shapes and required fields.
 
         Returns:
             dict: Validation results with status and any validation errors.

--- a/ocf_data_sampler/torch_datasets/sample/uk_regional.py
+++ b/ocf_data_sampler/torch_datasets/sample/uk_regional.py
@@ -1,4 +1,6 @@
 """PVNet UK Regional sample implementation for dataset handling and visualisation."""
+import logging
+from typing import Any
 
 import torch
 from typing_extensions import override
@@ -22,22 +24,143 @@ class UKRegionalSample(SampleBase):
 
     @override
     def to_numpy(self) -> NumpySample:
+        """Returns the data as a NumPy sample."""
         return self._data
 
     @override
     def save(self, path: str) -> None:
+        """Saves sample to the specified path in pickle format."""
         # Saves to pickle format
         torch.save(self._data, path)
 
     @classmethod
     @override
     def load(cls, path: str) -> "UKRegionalSample":
+        """Loads sample from the specified path.
+
+        Args:
+            path: Path to the saved sample file.
+
+        Returns:
+            A UKRegionalSample instance with the loaded data.
+        """
         # Loads from .pt format
         # TODO: We should move away from using torch.load(..., weights_only=False)
         return cls(torch.load(path, weights_only=False))
 
+    def validate_sample(self, config: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Validates that the sample has the expected structure and data shapes.
+
+        Args:
+            config: Optional configuration dict with expected shapes and required fields.
+                If None, uses default validation rules.
+
+        Returns:
+            dict: Validation results with status and any validation errors.
+        """
+        validation_result = {
+            "valid": True,
+            "errors": [],
+        }
+
+        # Default config if none provided
+        if config is None:
+            config = {
+                "required_keys": [
+                    GSPSampleKey.gsp,
+                    NWPSampleKey.nwp,
+                    SatelliteSampleKey.satellite_actual,
+                ],
+                "expected_shapes": {
+                    GSPSampleKey.gsp: (7,),
+                },
+            }
+
+        # Check for required keys
+        for key in config.get("required_keys", []):
+            if key not in self._data:
+                validation_result["valid"] = False
+                validation_result["errors"].append(f"Missing required key: {key}")
+
+        # Check data shapes
+        for key, expected_shape in config.get("expected_shapes", {}).items():
+            if key in self._data:
+                actual_shape = self._data[key].shape
+                # Check if shapes match, accounting for None which means "any size"
+                shape_valid = True
+                if len(actual_shape) != len(expected_shape):
+                    shape_valid = False
+                else:
+                    for actual_dim, expected_dim in zip(actual_shape, expected_shape, strict=False):
+                        if expected_dim is not None and actual_dim != expected_dim:
+                            shape_valid = False
+                            break
+
+                if not shape_valid:
+                    validation_result["valid"] = False
+                    validation_result["errors"].append(
+                        f"Shape mismatch for {key}: expected {expected_shape}, got {actual_shape}",
+                    )
+
+        # Special checks for NWP data which has a nested structure
+        if NWPSampleKey.nwp in self._data:
+            nwp_data = self._data[NWPSampleKey.nwp]
+            if not isinstance(nwp_data, dict):
+                validation_result["valid"] = False
+                validation_result["errors"].append("NWP data should be a dictionary")
+            else:
+                # Validate NWP data structure for each provider (ukv, etc.)
+                for provider, provider_data in nwp_data.items():
+                    if "nwp" not in provider_data:
+                        validation_result["valid"] = False
+                        validation_result["errors"].append(
+                            f"Missing 'nwp' key in NWP data for {provider}",
+                        )
+
+                    # Check expected shape of NWP data if configured
+                    if config.get("nwp_shape") and "nwp" in provider_data:
+                        # For NWP, we check dimensions after the first one (which is time)
+                        # and potentially after channels
+                        nwp_array = provider_data["nwp"]
+                        # Get last two dimensions (height, width)
+                        spatial_dims = nwp_array.shape[-2:]
+
+                        if tuple(spatial_dims) != config.get("nwp_shape"):
+                            validation_result["valid"] = False
+                            validation_result["errors"].append(
+                                f"NWP shape mismatch for {provider}: "
+                                f"expected {config.get('nwp_shape')} for spatial dimensions, "
+                                f"got {spatial_dims}",
+                            )
+
+        # Add satellite data validation
+        if SatelliteSampleKey.satellite_actual in self._data:
+            sat_data = self._data[SatelliteSampleKey.satellite_actual]
+
+            # Get satellite spatial dimensions (last two dimensions)
+            if len(sat_data.shape) >= 2:
+                spatial_dims = sat_data.shape[-2:]
+
+                # Check specific satellite shape if provided in config
+                if config.get("satellite_shape"):
+                    expected_spatial_dims = config.get("satellite_shape")[-2:]
+                    if spatial_dims != expected_spatial_dims:
+                        validation_result["valid"] = False
+                        validation_result["errors"].append(
+                            f"Satellite spatial dimensions mismatch: "
+                            f"expected {expected_spatial_dims}, got {spatial_dims}",
+                        )
+            else:
+                validation_result["valid"] = False
+                validation_result["errors"].append(
+                    f"Satellite data should have at least 2 dimensions, got shape {sat_data.shape}",
+                )
+
+        return validation_result
+
     @override
     def plot(self) -> None:
+        """Plots the sample data for visualization."""
         from matplotlib import pyplot as plt
 
         fig, axes = plt.subplots(2, 2, figsize=(12, 8))
@@ -58,10 +181,10 @@ class UKRegionalSample(SampleBase):
             axes[0, 0].set_title("GSP Generation")
 
         if "solar_azimuth" in self._data and "solar_elevation" in self._data:
-                    axes[1, 1].plot(self._data["solar_azimuth"], label="Azimuth")
-                    axes[1, 1].plot(self._data["solar_elevation"], label="Elevation")
-                    axes[1, 1].set_title("Solar Position")
-                    axes[1, 1].legend()
+            axes[1, 1].plot(self._data["solar_azimuth"], label="Azimuth")
+            axes[1, 1].plot(self._data["solar_elevation"], label="Elevation")
+            axes[1, 1].set_title("Solar Position")
+            axes[1, 1].legend()
 
         if SatelliteSampleKey.satellite_actual in self._data:
             axes[1, 0].imshow(self._data[SatelliteSampleKey.satellite_actual])
@@ -69,3 +192,51 @@ class UKRegionalSample(SampleBase):
 
         plt.tight_layout()
         plt.show()
+
+
+def validate_samples(
+    samples: list[UKRegionalSample],
+    config_or_path: dict[str, Any] | str | None = None,
+) -> dict[str, Any]:
+    """Validates a collection of UKRegionalSample objects.
+
+    Args:
+        samples: List of UKRegionalSample objects
+        config_or_path: Either a configuration dictionary or path to a validation config file
+
+    Returns:
+        dict: Summary of validation results
+    """
+    # Determine if config_or_path is a path or already a config dict
+    config = None
+    if config_or_path is not None:
+        if isinstance(config_or_path, dict):
+            config = config_or_path
+        else:
+            # Assume it's a path
+            import yaml
+            try:
+                with open(config_or_path) as f:
+                    config = yaml.safe_load(f)
+            except Exception as e:
+                logging.warning(f"Failed to load config from {config_or_path}: {e}")
+
+    results = {
+        "total_samples": len(samples),
+        "valid_samples": 0,
+        "invalid_samples": 0,
+        "error_summary": {},
+    }
+
+    for i, sample in enumerate(samples):
+        validation = sample.validate_sample(config)
+        if validation["valid"]:
+            results["valid_samples"] += 1
+        else:
+            results["invalid_samples"] += 1
+            for error in validation["errors"]:
+                if error not in results["error_summary"]:
+                    results["error_summary"][error] = []
+                results["error_summary"][error].append(i)
+
+    return results

--- a/ocf_data_sampler/torch_datasets/sample/uk_regional.py
+++ b/ocf_data_sampler/torch_datasets/sample/uk_regional.py
@@ -82,8 +82,8 @@ class UKRegionalSample(SampleBase):
 
         # Checks for NWP data - nested structure
         nwp_key = NWPSampleKey.nwp
-        if nwp_key in expected_shapes and expected_shapes[nwp_key] and nwp_key not in self._data:
-             raise ValueError(f"Configuration expects NWP data ('{nwp_key}') but is missing.")
+        if nwp_key in expected_shapes and nwp_key not in self._data:
+            raise ValueError(f"Configuration expects NWP data ('{nwp_key}') but is missing.")
 
         # Check NWP structure and shapes if data exists
         if nwp_key in self._data:
@@ -121,6 +121,22 @@ class UKRegionalSample(SampleBase):
                 expected_shape=expected_shapes[sat_key],
                 name="Satellite data",
             )
+
+        # Validate solar coordinates data
+        solar_keys = ["solar_azimuth", "solar_elevation"]
+        # Check if solar coordinate is expected but missing
+        for solar_key in solar_keys:
+            if solar_key in expected_shapes and solar_key not in self._data:
+                raise ValueError(f"Configuration expects {solar_key} data but is missing.")
+
+            # Check solar coordinate shape if data exists and is expected
+            if solar_key in self._data and solar_key in expected_shapes:
+                solar_data = self._data[solar_key]
+                check_dimensions(
+                    actual_shape=solar_data.shape,
+                    expected_shape=expected_shapes[solar_key],
+                    name=f"{solar_key.replace('_', ' ').title()} data",
+                )
 
         return True
 

--- a/ocf_data_sampler/torch_datasets/sample/uk_regional.py
+++ b/ocf_data_sampler/torch_datasets/sample/uk_regional.py
@@ -1,17 +1,18 @@
 """PVNet UK Regional sample implementation for dataset handling and visualisation."""
+
 import logging
 
 import torch
 from typing_extensions import override
 
+from ocf_data_sampler.config.load import load_yaml_configuration
 from ocf_data_sampler.numpy_sample import (
     GSPSampleKey,
     NWPSampleKey,
     SatelliteSampleKey,
 )
 from ocf_data_sampler.numpy_sample.common_types import NumpySample
-
-from .base import SampleBase
+from ocf_data_sampler.torch_datasets.sample.base import SampleBase
 
 
 class UKRegionalSample(SampleBase):
@@ -208,10 +209,9 @@ def validate_samples(
         if isinstance(config_or_path, dict):
             config = config_or_path
         else:
-            import yaml
             try:
-                with open(config_or_path) as f:
-                    config = yaml.safe_load(f)
+                config_obj = load_yaml_configuration(config_or_path)
+                config = config_obj.dict()
             except Exception as e:
                 logging.warning(f"Failed to load config from {config_or_path}: {e}")
 

--- a/ocf_data_sampler/torch_datasets/sample/uk_regional.py
+++ b/ocf_data_sampler/torch_datasets/sample/uk_regional.py
@@ -1,5 +1,6 @@
 """PVNet UK Regional sample implementation for dataset handling and visualisation."""
 import logging
+
 import torch
 from typing_extensions import override
 

--- a/ocf_data_sampler/torch_datasets/sample/uk_regional.py
+++ b/ocf_data_sampler/torch_datasets/sample/uk_regional.py
@@ -1,7 +1,5 @@
 """PVNet UK Regional sample implementation for dataset handling and visualisation."""
 import logging
-from typing import Any
-
 import torch
 from typing_extensions import override
 
@@ -48,7 +46,7 @@ class UKRegionalSample(SampleBase):
         # TODO: We should move away from using torch.load(..., weights_only=False)
         return cls(torch.load(path, weights_only=False))
 
-    def validate_sample(self, config: dict[str, Any] | None = None) -> dict[str, Any]:
+    def validate_sample(self, config: dict | None = None) -> dict:
         """Validates that the sample has the expected structure and data shapes.
 
         Args:
@@ -196,8 +194,8 @@ class UKRegionalSample(SampleBase):
 
 def validate_samples(
     samples: list[UKRegionalSample],
-    config_or_path: dict[str, Any] | str | None = None,
-) -> dict[str, Any]:
+    config_or_path: dict[str, object] | str | None = None,
+) -> dict[str, object]:
     """Validates a collection of UKRegionalSample objects.
 
     Args:

--- a/ocf_data_sampler/torch_datasets/sample/uk_regional.py
+++ b/ocf_data_sampler/torch_datasets/sample/uk_regional.py
@@ -116,22 +116,18 @@ class UKRegionalSample(SampleBase):
         # Check satellite shape if data exists and is expected
         if sat_key in self._data and sat_key in expected_shapes:
             sat_data = self._data[sat_key]
-            if len(sat_data.shape) < 2:
-                raise ValueError(
-                    f"Satellite data ('{sat_key}') should have at least 2 dimensions, "
-                    f"got shape {sat_data.shape}",
-                )
-
-            actual_spatial_dims = sat_data.shape
-            expected_spatial_dims = expected_shapes[sat_key]
-
             check_dimensions(
-                actual_shape=tuple(actual_spatial_dims),
-                expected_shape=expected_spatial_dims,
-                name="Satellite spatial dims",
+                actual_shape=sat_data.shape,
+                expected_shape=expected_shapes[sat_key],
+                name="Satellite data",
             )
 
-        return True
+        result = {
+            "status": "success",
+            "message": "Sample validated successfully with provided configuration.",
+        }
+
+        return result
 
     @override
     def plot(self) -> None:

--- a/ocf_data_sampler/torch_datasets/utils/validation_utils.py
+++ b/ocf_data_sampler/torch_datasets/utils/validation_utils.py
@@ -65,8 +65,7 @@ def calculate_expected_shapes(
 
         # Calculate NWP shape
         if hasattr(input_data, "nwp") and input_data.nwp is not None:
-            if NWPSampleKey.nwp not in expected_shapes:
-                expected_shapes[NWPSampleKey.nwp] = {}
+            expected_shapes[NWPSampleKey.nwp] = {}
 
             # Add shapes for each provider directly
             for provider_key, provider_config in input_data.nwp.items():

--- a/ocf_data_sampler/torch_datasets/utils/validation_utils.py
+++ b/ocf_data_sampler/torch_datasets/utils/validation_utils.py
@@ -74,7 +74,10 @@ def calculate_expected_shapes(
 
         # Calculate NWP shape
         if hasattr(input_data, "nwp") and input_data.nwp is not None:
-            nwp_shapes = {}
+            if NWPSampleKey.nwp not in expected_shapes:
+                expected_shapes[NWPSampleKey.nwp] = {}
+
+            # Add shapes for each provider directly
             for provider_key, provider_config in input_data.nwp.items():
                 time_span = (
                     provider_config.interval_end_minutes -
@@ -95,10 +98,14 @@ def calculate_expected_shapes(
                 num_channels = num_non_accum + num_accum
                 height = provider_config.image_size_pixels_height
                 width = provider_config.image_size_pixels_width
-                nwp_shapes[provider_key] = (num_timesteps, num_channels, height, width)
 
-            if nwp_shapes:
-                expected_shapes[NWPSampleKey.nwp] = nwp_shapes
+                # Store shape directly in nested dictionary
+                expected_shapes[NWPSampleKey.nwp][provider_key] = (
+                    num_timesteps,
+                    num_channels,
+                    height,
+                    width,
+                )
 
         # Calculate satellite shape
         if hasattr(input_data, "satellite") and input_data.satellite is not None:

--- a/ocf_data_sampler/torch_datasets/utils/validation_utils.py
+++ b/ocf_data_sampler/torch_datasets/utils/validation_utils.py
@@ -35,7 +35,7 @@ def check_dimensions(
 
 
 def calculate_expected_shapes(
-    config: Configuration | dict | None = None,
+    config: Configuration,
 ) -> dict[str, tuple[int, ...]]:
     """Calculate expected shapes from configuration.
 
@@ -47,9 +47,6 @@ def calculate_expected_shapes(
         Dictionary mapping data keys to their expected shapes (tuples of integers).
     """
     expected_shapes = {}
-
-    if config is None:
-        return expected_shapes
 
     # Calculate expected shapes from input_data if available
     if hasattr(config, "input_data"):
@@ -81,15 +78,7 @@ def calculate_expected_shapes(
                 resolution = provider_config.time_resolution_minutes
                 num_timesteps = (time_span // resolution) + 1
 
-                non_accum_channels = [
-                    c for c in provider_config.channels
-                    if c not in provider_config.accum_channels
-                ]
-
-                num_non_accum = len(non_accum_channels)
-                num_accum = len(provider_config.accum_channels)
-
-                num_channels = num_non_accum + num_accum
+                num_channels = len(provider_config.channels)
                 height = provider_config.image_size_pixels_height
                 width = provider_config.image_size_pixels_width
 

--- a/ocf_data_sampler/torch_datasets/utils/validation_utils.py
+++ b/ocf_data_sampler/torch_datasets/utils/validation_utils.py
@@ -6,32 +6,24 @@ from ocf_data_sampler.numpy_sample import GSPSampleKey, NWPSampleKey, SatelliteS
 
 def check_dimensions(
     actual_shape: tuple[int, ...],
-    expected_shape: tuple[int | None, ...],
+    expected_shape: tuple[int, ...],
     name: str,
 ) -> None:
     """Check if dimensions match between actual and expected shapes.
 
-    Allows `None` in `expected_shape` to act as a wildcard for that dimension.
-
     Args:
         actual_shape: The actual shape of the data (e.g., array.shape).
-        expected_shape: The expected shape, potentially with None as wildcards.
+        expected_shape: The expected shape.
         name: Name of the data component for clear error messages.
 
     Raises:
-        ValueError: If dimensions don't match according to the rules.
+        ValueError: If dimensions don't match.
     """
-    if len(actual_shape) != len(expected_shape):
+    if actual_shape != expected_shape:
         raise ValueError(
-            f"'{name}' shape dimension mismatch: "
-            f"Expected {len(expected_shape)} dimensions, got {len(actual_shape)} "
-            f"(Actual shape: {actual_shape}, Expected shape: {expected_shape})",
+            f"'{name}' shape mismatch: "
+            f"Actual shape: {actual_shape}, Expected shape: {expected_shape}",
         )
-
-    zipped_dims = zip(actual_shape, expected_shape, strict=True)
-    for i, (actual_dim, expected_dim) in enumerate(zipped_dims):
-        if expected_dim is not None and actual_dim != expected_dim:
-            raise ValueError(f"{name} shape mismatch at dimension {i}")
 
 
 def calculate_expected_shapes(
@@ -40,71 +32,64 @@ def calculate_expected_shapes(
     """Calculate expected shapes from configuration.
 
     Args:
-        config: Configuration object or dictionary with shape information.
-            If None, returns an empty dictionary.
+        config: Configuration object with shape information.
 
     Returns:
-        Dictionary mapping data keys to their expected shapes (tuples of integers).
+        Dictionary mapping data keys to their expected shapes.
     """
     expected_shapes = {}
+    input_data = config.input_data
 
-    # Calculate expected shapes from input_data if available
-    if hasattr(config, "input_data"):
-        input_data = config.input_data
+    # Calculate GSP shape
+    gsp_config = input_data.gsp
+    expected_shapes[GSPSampleKey.gsp] = (
+        _calculate_time_steps(
+            gsp_config.interval_start_minutes,
+            gsp_config.interval_end_minutes,
+            gsp_config.time_resolution_minutes,
+        ),
+    )
 
-        # Calculate GSP shape
-        if hasattr(input_data, "gsp") and input_data.gsp is not None:
-            gsp_config = input_data.gsp
-            time_span = (
-                gsp_config.interval_end_minutes -
-                gsp_config.interval_start_minutes
-            )
-            resolution = gsp_config.time_resolution_minutes
-            expected_length = (time_span // resolution) + 1
-            expected_shapes[GSPSampleKey.gsp] = (expected_length,)
+    # Calculate NWP shape for multiple providers
+    expected_shapes[NWPSampleKey.nwp] = {}
+    for provider_key, provider_config in input_data.nwp.items():
+        expected_shapes[NWPSampleKey.nwp][provider_key] = (
+            _calculate_time_steps(
+                provider_config.interval_start_minutes,
+                provider_config.interval_end_minutes,
+                provider_config.time_resolution_minutes,
+            ),
+            len(provider_config.channels),
+            provider_config.image_size_pixels_height,
+            provider_config.image_size_pixels_width,
+        )
 
-        # Calculate NWP shape
-        if hasattr(input_data, "nwp") and input_data.nwp is not None:
-            expected_shapes[NWPSampleKey.nwp] = {}
-
-            # Add shapes for each provider directly
-            for provider_key, provider_config in input_data.nwp.items():
-                time_span = (
-                    provider_config.interval_end_minutes -
-                    provider_config.interval_start_minutes
-                )
-
-                resolution = provider_config.time_resolution_minutes
-                num_timesteps = (time_span // resolution) + 1
-
-                num_channels = len(provider_config.channels)
-                height = provider_config.image_size_pixels_height
-                width = provider_config.image_size_pixels_width
-
-                # Store shape directly in nested dictionary
-                expected_shapes[NWPSampleKey.nwp][provider_key] = (
-                    num_timesteps,
-                    num_channels,
-                    height,
-                    width,
-                )
-
-        # Calculate satellite shape
-        if hasattr(input_data, "satellite") and input_data.satellite is not None:
-            sat_config = input_data.satellite
-            channels = len(sat_config.channels)
-            time_span = (
-                sat_config.interval_end_minutes -
-                sat_config.interval_start_minutes
-            )
-            resolution = sat_config.time_resolution_minutes
-            time_steps = (time_span // resolution) + 1
-
-            expected_shapes[SatelliteSampleKey.satellite_actual] = (
-                time_steps,
-                channels,
-                sat_config.image_size_pixels_height,
-                sat_config.image_size_pixels_width,
-            )
+    # Calculate satellite shape
+    sat_config = input_data.satellite
+    expected_shapes[SatelliteSampleKey.satellite_actual] = (
+        _calculate_time_steps(
+            sat_config.interval_start_minutes,
+            sat_config.interval_end_minutes,
+            sat_config.time_resolution_minutes,
+        ),
+        len(sat_config.channels),
+        sat_config.image_size_pixels_height,
+        sat_config.image_size_pixels_width,
+    )
 
     return expected_shapes
+
+
+def _calculate_time_steps(start_minutes: int, end_minutes: int, resolution_minutes: int) -> int:
+    """Calculate number of time steps based on interval and resolution.
+
+    Args:
+        start_minutes: Start of interval in minutes
+        end_minutes: End of interval in minutes
+        resolution_minutes: Time resolution in minutes
+
+    Returns:
+        Number of time steps
+    """
+    time_span = end_minutes - start_minutes
+    return (time_span // resolution_minutes) + 1

--- a/ocf_data_sampler/torch_datasets/utils/validation_utils.py
+++ b/ocf_data_sampler/torch_datasets/utils/validation_utils.py
@@ -1,0 +1,30 @@
+"""Validate sample shape against expected shape - utility function."""
+
+def check_dimensions(
+    actual_shape: tuple[int, ...],
+    expected_shape: tuple[int | None, ...],
+    name: str,
+) -> None:
+    """Check if dimensions match between actual and expected shapes.
+
+    Allows `None` in `expected_shape` to act as a wildcard for that dimension.
+
+    Args:
+        actual_shape: The actual shape of the data (e.g., array.shape).
+        expected_shape: The expected shape, potentially with None as wildcards.
+        name: Name of the data component for clear error messages.
+
+    Raises:
+        ValueError: If dimensions don't match according to the rules.
+    """
+    if len(actual_shape) != len(expected_shape):
+        raise ValueError(
+            f"'{name}' shape dimension mismatch: "
+            f"Expected {len(expected_shape)} dimensions, got {len(actual_shape)} "
+            f"(Actual shape: {actual_shape}, Expected shape: {expected_shape})",
+        )
+
+    zipped_dims = zip(actual_shape, expected_shape, strict=True)
+    for i, (actual_dim, expected_dim) in enumerate(zipped_dims):
+        if expected_dim is not None and actual_dim != expected_dim:
+            raise ValueError(f"{name} shape mismatch at dimension {i}")

--- a/ocf_data_sampler/torch_datasets/utils/validation_utils.py
+++ b/ocf_data_sampler/torch_datasets/utils/validation_utils.py
@@ -77,6 +77,19 @@ def calculate_expected_shapes(
         sat_config.image_size_pixels_width,
     )
 
+    # Calculate solar coordinates shapes
+    solar_config = input_data.solar_position
+    # For solar azimuth
+    expected_shapes["solar_azimuth"] = (
+        _calculate_time_steps(
+            solar_config.interval_start_minutes,
+            solar_config.interval_end_minutes,
+            solar_config.time_resolution_minutes,
+        ),
+    )
+    # For solar elevation
+    expected_shapes["solar_elevation"] = expected_shapes["solar_azimuth"]
+
     return expected_shapes
 
 

--- a/ocf_data_sampler/torch_datasets/utils/validation_utils.py
+++ b/ocf_data_sampler/torch_datasets/utils/validation_utils.py
@@ -51,12 +51,6 @@ def calculate_expected_shapes(
     if config is None:
         return expected_shapes
 
-    # Start with configured expected shapes
-    if hasattr(config, "expected_shapes"):
-        expected_shapes.update(config.expected_shapes)
-    elif isinstance(config, dict) and "expected_shapes" in config:
-        expected_shapes.update(config["expected_shapes"])
-
     # Calculate expected shapes from input_data if available
     if hasattr(config, "input_data"):
         input_data = config.input_data

--- a/tests/test_data/configs/pvnet_test_config.yaml
+++ b/tests/test_data/configs/pvnet_test_config.yaml
@@ -46,3 +46,8 @@ input_data:
       IR_016:
         mean: 0.17594202
         std: 0.21462157
+
+  solar_position:
+    interval_start_minutes: -15
+    interval_end_minutes: 15
+    time_resolution_minutes: 5

--- a/tests/torch_datasets/sample/test_uk_regional_sample.py
+++ b/tests/torch_datasets/sample/test_uk_regional_sample.py
@@ -102,7 +102,7 @@ def input_data_configuration():
                 "ukv": {
                     "image_size_pixels_height": 3,
                     "image_size_pixels_width": 3,
-                }
+                },
             },
             "satellite": {
                 "channels": ["HRV"],
@@ -203,11 +203,11 @@ def test_validate_sample_with_missing_keys(numpy_sample, custom_configuration):
     # Use config that requires satellite data
     config_with_satellite = custom_configuration.copy()
     config_with_satellite["required_keys"] = [
-        GSPSampleKey.gsp, 
-        NWPSampleKey.nwp, 
-        SatelliteSampleKey.satellite_actual
+        GSPSampleKey.gsp,
+        NWPSampleKey.nwp,
+        SatelliteSampleKey.satellite_actual,
     ]
-    
+
     with pytest.raises(ValueError, match="Missing required key: satellite_actual"):
         sample.validate_sample(config_with_satellite)
 

--- a/tests/torch_datasets/sample/test_uk_regional_sample.py
+++ b/tests/torch_datasets/sample/test_uk_regional_sample.py
@@ -135,14 +135,10 @@ def validation_config_file(tmp_path):
 def test_validate_sample(numpy_sample):
     """Test the validate_sample method with default config"""
     sample = UKRegionalSample(numpy_sample)
-    validation_result = sample.validate_sample()
 
     # Assert validation structure
-    assert isinstance(validation_result, dict)
-    assert "valid" in validation_result
-    assert "errors" in validation_result
-    assert validation_result["valid"] is True
-    assert len(validation_result["errors"]) == 0
+    result = sample.validate_sample()
+    assert result is True
 
 
 def test_validate_sample_with_custom_config(numpy_sample):
@@ -158,9 +154,9 @@ def test_validate_sample_with_custom_config(numpy_sample):
         "nwp_shape": (2, 2),
     }
 
-    validation_result = sample.validate_sample(custom_config)
-    assert validation_result["valid"] is True
-    assert len(validation_result["errors"]) == 0
+    # Assertion whether function returns True
+    result = sample.validate_sample(custom_config)
+    assert result is True
 
 
 def test_validate_sample_with_missing_keys(numpy_sample):
@@ -182,16 +178,13 @@ def test_validate_sample_with_missing_keys(numpy_sample):
         ],
     }
 
-    validation_result = sample.validate_sample(config)
-    assert validation_result["valid"] is False
-    assert any(
-        "Missing required key: satellite_actual" in error
-        for error in validation_result["errors"]
-    )
+    with pytest.raises(AssertionError, match="Missing required key: satellite_actual"):
+        sample.validate_sample(config)
+
 
 def test_validate_sample_with_wrong_shapes(numpy_sample):
     """Test validation with incorrect data shapes"""
-    # Create a copy of sample with wrong GSP shape
+    # Create copy of sample with wrong GSP shape
     modified_data = numpy_sample.copy()
     modified_data[GSPSampleKey.gsp] = np.random.rand(10)
 
@@ -203,6 +196,5 @@ def test_validate_sample_with_wrong_shapes(numpy_sample):
         },
     }
 
-    validation_result = sample.validate_sample(config)
-    assert validation_result["valid"] is False
-    assert any("Shape mismatch for gsp" in error for error in validation_result["errors"])
+    with pytest.raises(AssertionError, match="Shape mismatch for gsp at dimension 0"):
+        sample.validate_sample(config)

--- a/tests/torch_datasets/sample/test_uk_regional_sample.py
+++ b/tests/torch_datasets/sample/test_uk_regional_sample.py
@@ -112,9 +112,8 @@ def test_to_numpy(numpy_sample):
     assert isinstance(numpy_data["nwp"]["ukv"]["nwp"], np.ndarray)
     assert numpy_data[GSPSampleKey.gsp].shape == (7,)
 
-# Add these tests to the existing test_uk_regional_sample.py file
 
-# Add this fixture to create a validation config file
+# Validation config file as fixture
 @pytest.fixture
 def validation_config_file(tmp_path):
     """Create a validation config file for testing"""
@@ -138,12 +137,10 @@ def test_validate_sample(numpy_sample):
     sample = UKRegionalSample(numpy_sample)
     validation_result = sample.validate_sample()
 
-    # Check validation structure
+    # Assert validation structure
     assert isinstance(validation_result, dict)
     assert "valid" in validation_result
     assert "errors" in validation_result
-
-    # Should be valid for the default fixture data
     assert validation_result["valid"] is True
     assert len(validation_result["errors"]) == 0
 
@@ -152,7 +149,7 @@ def test_validate_sample_with_custom_config(numpy_sample):
     """Test the validate_sample method with custom config"""
     sample = UKRegionalSample(numpy_sample)
 
-    # Create a custom config
+    # Create custom config
     custom_config = {
         "required_keys": [GSPSampleKey.gsp, NWPSampleKey.nwp],
         "expected_shapes": {
@@ -168,16 +165,15 @@ def test_validate_sample_with_custom_config(numpy_sample):
 
 def test_validate_sample_with_missing_keys(numpy_sample):
     """Test validation with missing required keys"""
-    # Create a copy of the sample without satellite data
+    # Create copy of sample without satellite data
     modified_data = {
         "nwp": numpy_sample["nwp"],
         GSPSampleKey.gsp: numpy_sample[GSPSampleKey.gsp],
-        # Satellite key intentionally removed
     }
 
     sample = UKRegionalSample(modified_data)
 
-    # Create a config that requires satellite data
+    # Create config with satellite data
     config = {
         "required_keys": [
             GSPSampleKey.gsp,
@@ -195,7 +191,7 @@ def test_validate_sample_with_missing_keys(numpy_sample):
 
 def test_validate_sample_with_wrong_shapes(numpy_sample):
     """Test validation with incorrect data shapes"""
-    # Create a copy of the sample with wrong GSP shape
+    # Create a copy of sample with wrong GSP shape
     modified_data = numpy_sample.copy()
     modified_data[GSPSampleKey.gsp] = np.random.rand(10)
 
@@ -216,13 +212,11 @@ def test_validate_samples_function(numpy_sample):
     """Test the validate_samples function for batch validation"""
     # Create one valid and one invalid sample
     valid_sample = UKRegionalSample(numpy_sample)
-
-    # Create an invalid sample with wrong GSP shape
     modified_data = numpy_sample.copy()
     modified_data[GSPSampleKey.gsp] = np.random.rand(10)
     invalid_sample = UKRegionalSample(modified_data)
 
-    # Test batch validation with in-memory config instead of file
+    # Test batch validation with config instead of file
     samples = [valid_sample, invalid_sample]
     config = {
         "required_keys": [
@@ -235,7 +229,6 @@ def test_validate_samples_function(numpy_sample):
         },
     }
 
-    # Pass the config directly instead of via file path
     results = validate_samples(samples, config)
 
     assert results["total_samples"] == 2
@@ -243,6 +236,6 @@ def test_validate_samples_function(numpy_sample):
     assert results["invalid_samples"] == 1
     assert len(results["error_summary"]) > 0
 
-    # Also test without a config
+    # Consider without a config
     results = validate_samples(samples)
     assert results["total_samples"] == 2

--- a/tests/torch_datasets/sample/test_uk_regional_sample.py
+++ b/tests/torch_datasets/sample/test_uk_regional_sample.py
@@ -93,8 +93,8 @@ def test_to_numpy(numpy_sample):
 def test_validate_sample(numpy_sample, pvnet_configuration_object: Configuration):
     """Test the validate_sample method succeeds with a loaded Configuration object."""
     sample = UKRegionalSample(numpy_sample)
-    result = sample.validate_sample(pvnet_configuration_object)    
-    
+    result = sample.validate_sample(pvnet_configuration_object)
+
     # Assert success with config object
     assert isinstance(result, dict)
     assert result["status"] == "success"

--- a/tests/torch_datasets/sample/test_uk_regional_sample.py
+++ b/tests/torch_datasets/sample/test_uk_regional_sample.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 from ocf_data_sampler.numpy_sample import GSPSampleKey, NWPSampleKey, SatelliteSampleKey
-from ocf_data_sampler.torch_datasets.sample.uk_regional import UKRegionalSample, validate_samples
+from ocf_data_sampler.torch_datasets.sample.uk_regional import UKRegionalSample
 
 
 @pytest.fixture
@@ -206,36 +206,3 @@ def test_validate_sample_with_wrong_shapes(numpy_sample):
     validation_result = sample.validate_sample(config)
     assert validation_result["valid"] is False
     assert any("Shape mismatch for gsp" in error for error in validation_result["errors"])
-
-
-def test_validate_samples_function(numpy_sample):
-    """Test the validate_samples function for batch validation"""
-    # Create one valid and one invalid sample
-    valid_sample = UKRegionalSample(numpy_sample)
-    modified_data = numpy_sample.copy()
-    modified_data[GSPSampleKey.gsp] = np.random.rand(10)
-    invalid_sample = UKRegionalSample(modified_data)
-
-    # Test batch validation with config instead of file
-    samples = [valid_sample, invalid_sample]
-    config = {
-        "required_keys": [
-            GSPSampleKey.gsp,
-            NWPSampleKey.nwp,
-            SatelliteSampleKey.satellite_actual,
-        ],
-        "expected_shapes": {
-            GSPSampleKey.gsp: (7,),
-        },
-    }
-
-    results = validate_samples(samples, config)
-
-    assert results["total_samples"] == 2
-    assert results["valid_samples"] == 1
-    assert results["invalid_samples"] == 1
-    assert len(results["error_summary"]) > 0
-
-    # Consider without a config
-    results = validate_samples(samples)
-    assert results["total_samples"] == 2

--- a/tests/torch_datasets/sample/test_uk_regional_sample.py
+++ b/tests/torch_datasets/sample/test_uk_regional_sample.py
@@ -93,8 +93,11 @@ def test_to_numpy(numpy_sample):
 def test_validate_sample(numpy_sample, pvnet_configuration_object: Configuration):
     """Test the validate_sample method succeeds with a loaded Configuration object."""
     sample = UKRegionalSample(numpy_sample)
-    result = sample.validate_sample(pvnet_configuration_object)
-    assert result is True
+    result = sample.validate_sample(pvnet_configuration_object)    
+    
+    # Assert success with config object
+    assert isinstance(result, dict)
+    assert result["status"] == "success"
 
 
 def test_validate_sample_with_missing_keys(numpy_sample, pvnet_configuration_object: Configuration):

--- a/tests/torch_datasets/sample/test_uk_regional_sample.py
+++ b/tests/torch_datasets/sample/test_uk_regional_sample.py
@@ -178,7 +178,7 @@ def test_validate_sample_with_missing_keys(numpy_sample):
         ],
     }
 
-    with pytest.raises(AssertionError, match="Missing required key: satellite_actual"):
+    with pytest.raises(ValueError, match="Missing required key: satellite_actual"):
         sample.validate_sample(config)
 
 
@@ -196,5 +196,5 @@ def test_validate_sample_with_wrong_shapes(numpy_sample):
         },
     }
 
-    with pytest.raises(AssertionError, match="Shape mismatch for gsp at dimension 0"):
+    with pytest.raises(ValueError, match="Shape mismatch for gsp at dimension 0"):
         sample.validate_sample(config)

--- a/tests/torch_datasets/sample/test_uk_regional_sample.py
+++ b/tests/torch_datasets/sample/test_uk_regional_sample.py
@@ -95,9 +95,7 @@ def test_validate_sample(numpy_sample, pvnet_configuration_object: Configuration
     sample = UKRegionalSample(numpy_sample)
     result = sample.validate_sample(pvnet_configuration_object)
 
-    # Assert success with config object
-    assert isinstance(result, dict)
-    assert result["status"] == "success"
+    assert result is True
 
 
 def test_validate_sample_with_missing_keys(numpy_sample, pvnet_configuration_object: Configuration):
@@ -123,6 +121,5 @@ def test_validate_sample_with_wrong_shapes(numpy_sample, pvnet_configuration_obj
 
     sample = UKRegionalSample(modified_data)
 
-    # Depends on GSP shape calculated from pvnet_configuration_object
-    with pytest.raises(ValueError, match="GSP shape mismatch at dimension 0"):
+    with pytest.raises(ValueError, match="'GSP' shape mismatch: Actual shape:"):
         sample.validate_sample(pvnet_configuration_object)

--- a/tests/torch_datasets/sample/test_uk_regional_sample.py
+++ b/tests/torch_datasets/sample/test_uk_regional_sample.py
@@ -113,25 +113,6 @@ def test_to_numpy(numpy_sample):
     assert numpy_data[GSPSampleKey.gsp].shape == (7,)
 
 
-# Validation config file as fixture
-@pytest.fixture
-def validation_config_file(tmp_path):
-    """Create a validation config file for testing"""
-    config_content = """
-    required_keys:
-      - gsp
-      - nwp
-      - satellite_actual
-    expected_shapes:
-      gsp: [7]
-    nwp_shape: [2, 2]
-    satellite_shape: [2, 2]
-    """
-    config_file = tmp_path / "validation_config.yaml"
-    config_file.write_text(config_content)
-    return str(config_file)
-
-
 def test_validate_sample(numpy_sample):
     """Test the validate_sample method with default config"""
     sample = UKRegionalSample(numpy_sample)

--- a/tests/torch_datasets/sample/test_uk_regional_sample.py
+++ b/tests/torch_datasets/sample/test_uk_regional_sample.py
@@ -7,113 +7,40 @@ import tempfile
 import numpy as np
 import pytest
 
+from ocf_data_sampler.config import Configuration
+from ocf_data_sampler.config.load import load_yaml_configuration
 from ocf_data_sampler.numpy_sample import GSPSampleKey, NWPSampleKey, SatelliteSampleKey
 from ocf_data_sampler.torch_datasets.sample.uk_regional import UKRegionalSample
 
 
 @pytest.fixture
-def pvnet_config_filename(tmp_path):
-    """Minimal config file - testing"""
-    config_content = """
-    input_data:
-        gsp:
-            zarr_path: ""
-            time_resolution_minutes: 30
-            interval_start_minutes: -180
-            interval_end_minutes: 0
-        nwp:
-            ukv:
-                zarr_path: ""
-                image_size_pixels_height: 64
-                image_size_pixels_width: 64
-                time_resolution_minutes: 60
-                interval_start_minutes: -180
-                interval_end_minutes: 0
-                channels: ["t", "dswrf"]
-                provider: "ukv"
-        satellite:
-            zarr_path: ""
-            image_size_pixels_height: 64
-            image_size_pixels_width: 64
-            time_resolution_minutes: 30
-            interval_start_minutes: -180
-            interval_end_minutes: 0
-            channels: ["HRV"]
-    """
-    config_file = tmp_path / "test_config.yaml"
-    config_file.write_text(config_content)
-    return str(config_file)
-
-
-@pytest.fixture
 def numpy_sample():
     """Synthetic data generation"""
-    # Field / spatial coordinates
+    expected_gsp_shape = (7,)
+    expected_nwp_ukv_shape = (4, 1, 2, 2)
+    expected_sat_shape = (7, 1, 2, 2)
+
+    # Create NWP data with the expected shape
     nwp_data = {
-        "nwp": np.random.rand(4, 1, 3, 3),
-        "x": np.array([1, 2, 3]),
-        "y": np.array([1, 2, 3]),
-        NWPSampleKey.channel_names: ["test_channel"],
+        "nwp": np.random.rand(*expected_nwp_ukv_shape),
+        "x": np.array([1, 2]),
+        "y": np.array([1, 2]),
+        NWPSampleKey.channel_names: ["t"],
     }
+
     return {
         "nwp": {
             "ukv": nwp_data,
         },
-        GSPSampleKey.gsp: np.random.rand(7),
-        SatelliteSampleKey.satellite_actual: np.random.rand(7, 1, 2, 2),
+        GSPSampleKey.gsp: np.random.rand(*expected_gsp_shape),
+        SatelliteSampleKey.satellite_actual: np.random.rand(*expected_sat_shape),
     }
 
 
 @pytest.fixture
-def custom_configuration():
-    """Custom configuration for testing"""
-    return {
-        "required_keys": [GSPSampleKey.gsp, NWPSampleKey.nwp],
-        "expected_shapes": {
-            GSPSampleKey.gsp: (7,),
-            NWPSampleKey.nwp: (4, 1, 3, 3),
-            SatelliteSampleKey.satellite_actual: (7, 1, 2, 2),
-        },
-    }
-
-
-@pytest.fixture
-def shape_configuration():
-    """Configuration with expected shapes for testing"""
-    return {
-        "expected_shapes": {
-            GSPSampleKey.gsp: (7,),
-        },
-    }
-
-
-@pytest.fixture
-def input_data_configuration():
-    """Config for testing shape calculation"""
-    return {
-        "required_keys": [GSPSampleKey.gsp, NWPSampleKey.nwp],
-        "input_data": {
-            "gsp": {
-                "time_resolution_minutes": 30,
-                "interval_start_minutes": -180,
-                "interval_end_minutes": 0,
-            },
-            "nwp": {
-                "ukv": {
-                    "image_size_pixels_height": 3,
-                    "image_size_pixels_width": 3,
-                },
-            },
-            "satellite": {
-                "channels": ["HRV"],
-                "time_resolution_minutes": 30,
-                "interval_start_minutes": -180,
-                "interval_end_minutes": 0,
-                "image_size_pixels_height": 2,
-                "image_size_pixels_width": 2,
-            },
-        },
-    }
+def pvnet_configuration_object(pvnet_config_filename) -> Configuration:
+    """Loads the configuration from the temporary file path."""
+    return load_yaml_configuration(pvnet_config_filename)
 
 
 def test_sample_save_load(numpy_sample):
@@ -163,62 +90,36 @@ def test_to_numpy(numpy_sample):
     assert numpy_data[GSPSampleKey.gsp].shape == (7,)
 
 
-def test_validate_sample(numpy_sample, custom_configuration):
-    """Test the validate_sample method with config"""
+def test_validate_sample(numpy_sample, pvnet_configuration_object: Configuration):
+    """Test the validate_sample method succeeds with a loaded Configuration object."""
     sample = UKRegionalSample(numpy_sample)
-
-    # Assert validation with provided config
-    result = sample.validate_sample(custom_configuration)
+    result = sample.validate_sample(pvnet_configuration_object)
     assert result is True
 
 
-def test_validate_sample_with_custom_config(numpy_sample, custom_configuration):
-    """Test the validate_sample method with custom config"""
-
-    sample = UKRegionalSample(numpy_sample)
-
-    # Validate with the custom config
-    result = sample.validate_sample(custom_configuration)
-    assert result is True
-
-
-def test_validate_sample_with_input_data_config(numpy_sample, input_data_configuration):
-    """Test the validate_sample method with input_data configuration"""
-    sample = UKRegionalSample(numpy_sample)
-
-    # Validate with the input_data config
-    result = sample.validate_sample(input_data_configuration)
-    assert result is True
-
-
-def test_validate_sample_with_missing_keys(numpy_sample, custom_configuration):
-    """Test validation with missing required keys"""
-    # Make a copy to avoid modifying fixture
+def test_validate_sample_with_missing_keys(numpy_sample, pvnet_configuration_object: Configuration):
+    """Test validation raises ValueError when configured satellite data is missing."""
     modified_data = numpy_sample.copy()
+    sat_key = SatelliteSampleKey.satellite_actual
+    if sat_key in modified_data:
+        modified_data.pop(sat_key)
+    else:
+        pytest.fail(f"Fixture 'numpy_sample' did not contain the key to be removed: {sat_key}")
 
-    # Remove satellite data using pop()
-    modified_data.pop(SatelliteSampleKey.satellite_actual)
     sample = UKRegionalSample(modified_data)
+    expected_error_pattern = f"^Configuration expects Satellite data \\('{sat_key}'\\).*missing"
 
-    # Use config that requires satellite data
-    config_with_satellite = custom_configuration.copy()
-    config_with_satellite["required_keys"] = [
-        GSPSampleKey.gsp,
-        NWPSampleKey.nwp,
-        SatelliteSampleKey.satellite_actual,
-    ]
-
-    with pytest.raises(ValueError, match="Missing required key: satellite_actual"):
-        sample.validate_sample(config_with_satellite)
+    with pytest.raises(ValueError, match=expected_error_pattern):
+        sample.validate_sample(pvnet_configuration_object)
 
 
-def test_validate_sample_with_wrong_shapes(numpy_sample, shape_configuration):
-    """Test validation with incorrect data shapes"""
-    # Create copy of sample with wrong GSP shape
+def test_validate_sample_with_wrong_shapes(numpy_sample, pvnet_configuration_object: Configuration):
+    """Test validation raises ValueError when data shape is incorrect (GSP)."""
     modified_data = numpy_sample.copy()
     modified_data[GSPSampleKey.gsp] = np.random.rand(10)
 
     sample = UKRegionalSample(modified_data)
 
+    # Depends on GSP shape calculated from pvnet_configuration_object
     with pytest.raises(ValueError, match="GSP shape mismatch at dimension 0"):
-        sample.validate_sample(shape_configuration)
+        sample.validate_sample(pvnet_configuration_object)

--- a/tests/torch_datasets/test_site.py
+++ b/tests/torch_datasets/test_site.py
@@ -56,6 +56,7 @@ def test_site(tmp_path, site_config_filename):
         "satellite__time_utc",
         "nwp-ukv__channel",
         "nwp-ukv__y_osgb",
+        "solar_time_utc",
     }
 
     expected_coords_subset = {


### PR DESCRIPTION
Alongside updating related tests, two new functions:

validate_sample (inside UKRegionalSample class): Checks if individual sample meets criteria by verifying required keys exist, data shapes match expected dimensions and validating structure for NWP.

validate_samples: Processes multiple UKRegionalSample objects - applies validation to each using provided configuration.

Related to: https://github.com/openclimatefix/ocf-data-sampler/issues/227