### PR TITLE
Validate channels

### DIFF
--- a/ocf_data_sampler/config/model.py
+++ b/ocf_data_sampler/config/model.py
@@ -218,8 +218,8 @@ class NWP(TimeWindowMixin, DropoutMixin, SpatialWindowMixin, NormalisationConsta
         invalid_channels = set(self.accum_channels) - set(self.channels)
         if invalid_channels:
             raise ValueError(
-                f"NWP provider '{self.provider}': accum_channels contains "
-                f"invalid channels: {invalid_channels}",
+                f"NWP provider '{self.provider}': all values in 'accum_channels' should "
+                f"be present in 'channels'. Extra values found: {invalid_channels}",
             )
         return self
 

--- a/ocf_data_sampler/config/model.py
+++ b/ocf_data_sampler/config/model.py
@@ -7,7 +7,7 @@ Prefix with a protocol like s3:// to read from alternative filesystems.
 from collections.abc import Iterator
 from typing import Literal
 
-from pydantic import BaseModel, Field, RootModel, field_validator, model_validator
+from pydantic import BaseModel, Field, RootModel, ValidationInfo, field_validator, model_validator
 from typing_extensions import override
 
 NWP_PROVIDERS = [
@@ -211,6 +211,17 @@ class NWP(TimeWindowMixin, DropoutMixin, SpatialWindowMixin, NormalisationConsta
         " used to construct an example. If set to None, then the max staleness is set according to"
         " the maximum forecast horizon of the NWP and the requested forecast length.",
     )
+
+    @field_validator("accum_channels")
+    def validate_accum_channels_subset(cls, v: list[str], values: ValidationInfo) -> list[str]:
+        """Validate accum_channels is subset of channels."""
+        channels = values.data.get("channels", [])
+        invalid_channels = set(v) - set(channels)
+        if invalid_channels:
+            raise ValueError(
+                f"accum_channels contains channels not present in 'channels': {invalid_channels}",
+            )
+        return v
 
     @field_validator("provider")
     def validate_provider(cls, v: str) -> str:

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -135,8 +135,10 @@ def test_accum_channels_validation(test_config_filename):
 
     # Verify exact error message
     expected_error = (
-        rf"NWP provider '{nwp_name}': accum_channels contains channels "
-        rf"not found in 'channels': {{'invalid_channel'}}"
+        r"input_data.nwp.ukv\n"
+        r"  Value error, NWP provider 'ukv': all values in 'accum_channels' "
+        r"should be present in 'channels'\. "
+        r"Extra values found: {'invalid_channel'}.*"
     )
-    with pytest.raises(ValueError, match=expected_error):
+    with pytest.raises(ValidationError, match=expected_error):
         _ = Configuration(**invalid_config.model_dump())

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -135,7 +135,7 @@ def test_accum_channels_validation(test_config_filename):
 
     # Verify exact error message
     expected_error = (
-        r"input_data.nwp.ukv\n"
+        rf"input_data.nwp.{nwp_name}\n"
         fr"  Value error, NWP provider '{nwp_name}': all values in 'accum_channels' "
         r"should be present in 'channels'\. "
         r"Extra values found: {'invalid_channel'}.*"

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -120,3 +120,46 @@ def test_inconsistent_dropout_use(test_config_filename):
         match="To use dropout timedeltas dropout fraction should be > 0",
     ):
         _ = Configuration(**configuration.model_dump())
+
+
+def test_valid_accum_channels(test_config_filename):
+    """Test valid accum_channels with required normalization constants."""
+    configuration = load_yaml_configuration(test_config_filename)
+
+    # Get first NWP config
+    nwp_name = next(iter(configuration.input_data.nwp.root.keys()))
+    original_nwp = configuration.input_data.nwp[nwp_name]
+
+    # Create updated configuration
+    new_config_dict = configuration.model_dump()
+
+    # 1. Set valid accum_channel
+    target_channel = original_nwp.channels[0]
+    new_config_dict["input_data"]["nwp"][nwp_name]["accum_channels"] = [target_channel]
+
+    # 2. Add required diff_ normalization constants (split line)
+    norm_constants = new_config_dict["input_data"]["nwp"][nwp_name]["normalisation_constants"]
+    norm_constants[f"diff_{target_channel}"] = {
+        "mean": 0.0,  # Example values
+        "std": 1.0,
+    }
+
+    # Should now validate successfully
+    _ = Configuration(**new_config_dict)
+
+def test_invalid_accum_channels(test_config_filename):
+    """Test accum_channels with non-existent channel raises error."""
+    configuration = load_yaml_configuration(test_config_filename)
+
+    # Get first NWP config name
+    nwp_name = next(iter(configuration.input_data.nwp.root.keys()))
+
+    # Create invalid configuration
+    new_config_dict = configuration.model_dump()
+    new_config_dict["input_data"]["nwp"][nwp_name]["accum_channels"] = ["invalid_channel"]
+
+    with pytest.raises(
+        ValueError,
+        match=r"accum_channels contains channels not present in 'channels': {'invalid_channel'}",
+    ):
+        _ = Configuration(**new_config_dict)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -126,35 +126,28 @@ def test_valid_accum_channels(test_config_filename):
     """Test valid accum_channels with required normalization constants."""
     configuration = load_yaml_configuration(test_config_filename)
 
-    # Get first NWP config
     nwp_name = next(iter(configuration.input_data.nwp.root.keys()))
     original_nwp = configuration.input_data.nwp[nwp_name]
 
-    # Create updated configuration
     new_config_dict = configuration.model_dump()
 
-    # 1. Set valid accum_channel
     target_channel = original_nwp.channels[0]
     new_config_dict["input_data"]["nwp"][nwp_name]["accum_channels"] = [target_channel]
 
-    # 2. Add required diff_ normalization constants (split line)
     norm_constants = new_config_dict["input_data"]["nwp"][nwp_name]["normalisation_constants"]
     norm_constants[f"diff_{target_channel}"] = {
         "mean": 0.0,  # Example values
         "std": 1.0,
     }
 
-    # Should now validate successfully
-    _ = Configuration(**new_config_dict)
+    _ = Configuration(**new_config_dict) #should validate
 
 def test_invalid_accum_channels(test_config_filename):
     """Test accum_channels with non-existent channel raises error."""
     configuration = load_yaml_configuration(test_config_filename)
 
-    # Get first NWP config name
     nwp_name = next(iter(configuration.input_data.nwp.root.keys()))
 
-    # Create invalid configuration
     new_config_dict = configuration.model_dump()
     new_config_dict["input_data"]["nwp"][nwp_name]["accum_channels"] = ["invalid_channel"]
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -136,7 +136,7 @@ def test_accum_channels_validation(test_config_filename):
     # Verify exact error message
     expected_error = (
         r"input_data.nwp.ukv\n"
-        r"  Value error, NWP provider 'ukv': all values in 'accum_channels' "
+        fr"  Value error, NWP provider '{nwp_name}': all values in 'accum_channels' "
         r"should be present in 'channels'\. "
         r"Extra values found: {'invalid_channel'}.*"
     )

--- a/tests/test_data/configs/test_config.yaml
+++ b/tests/test_data/configs/test_config.yaml
@@ -19,7 +19,8 @@ input_data:
       time_resolution_minutes: 60
       channels:
         - t
-      accum_channels: ["t"]
+      accum_channels:
+        - t
       image_size_pixels_height: 2
       image_size_pixels_width: 2
       dropout_timedeltas_minutes: [-180]

--- a/tests/test_data/configs/test_config.yaml
+++ b/tests/test_data/configs/test_config.yaml
@@ -19,6 +19,7 @@ input_data:
       time_resolution_minutes: 60
       channels:
         - t
+      accum_channels: ["t"]
       image_size_pixels_height: 2
       image_size_pixels_width: 2
       dropout_timedeltas_minutes: [-180]
@@ -28,6 +29,9 @@ input_data:
         t:
           mean: 283.64913206
           std: 4.38818501
+        diff_t:
+          mean: 0.0
+          std: 1.0
 
   satellite:
     zarr_path: tests/data/sat_data.zarr


### PR DESCRIPTION
# Pull Request

## Description

This PR adds validation to ensure `accum_channels` specified in the NWP configuration are a subset of the configured `channels`. This prevents runtime errors when attempting to compute differences for channels not present in the data.

Key changes:
- Added Pydantic validator to check `accum_channels ⊂ channels`
- Added required normalization constant checks for diff_ prefixed channels
- Added comprehensive unit tests for both valid and invalid cases

Fixes #236

## How Has This Been Tested?

Added 2 new test cases in `tests/config/test_config.py`:
1. `test_valid_accum_channels`: Verifies valid configuration with:
   - accum_channels subset of channels
   - Proper diff_ normalization constants
2. `test_invalid_accum_channels`: Checks proper ValueError is raised when:
   - accum_channels contains non-existent channel
   - Error message specifies missing channels

Tests run via pytest with command:
```bash
pytest tests/config/test_config.py -k accum_channels
```

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings