### PR TITLE
gfs changes for open-data-pvnet

### DIFF
--- a/ocf_data_sampler/load/nwp/providers/gfs.py
+++ b/ocf_data_sampler/load/nwp/providers/gfs.py
@@ -27,8 +27,12 @@ def open_gfs(zarr_path: str | list[str]) -> xr.DataArray:
     nwp = nwp.rename({"variable": "channel"})  # `variable` appears when using `to_array`
 
     del gfs
+
     if "init_time" in nwp.dims:
         nwp = nwp.rename({"init_time": "init_time_utc"})
+    if "init_time_utc" not in nwp.dims:
+        raise ValueError("init_time_utc dimension not found in the gfs data. "
+                         "Note that init_time is rename to init_time_utc.")
 
     check_time_unique_increasing(nwp.init_time_utc)
     nwp = make_spatial_coords_increasing(nwp, x_coord="longitude", y_coord="latitude")

--- a/ocf_data_sampler/load/nwp/providers/gfs.py
+++ b/ocf_data_sampler/load/nwp/providers/gfs.py
@@ -28,12 +28,6 @@ def open_gfs(zarr_path: str | list[str]) -> xr.DataArray:
 
     del gfs
 
-    if "init_time" in nwp.dims:
-        nwp = nwp.rename({"init_time": "init_time_utc"})
-    if "init_time_utc" not in nwp.dims:
-        raise ValueError("init_time_utc dimension not found in the gfs data. "
-                         "Note that init_time is rename to init_time_utc.")
-
     check_time_unique_increasing(nwp.init_time_utc)
     nwp = make_spatial_coords_increasing(nwp, x_coord="longitude", y_coord="latitude")
 

--- a/ocf_data_sampler/load/nwp/providers/gfs.py
+++ b/ocf_data_sampler/load/nwp/providers/gfs.py
@@ -24,10 +24,12 @@ def open_gfs(zarr_path: str | list[str]) -> xr.DataArray:
     # Open data
     gfs: xr.Dataset = open_zarr_paths(zarr_path, time_dim="init_time_utc")
     nwp: xr.DataArray = gfs.to_array()
+    nwp = nwp.rename({"variable": "channel"})  # `variable` appears when using `to_array`
 
     del gfs
+    if "init_time" in nwp.dims:
+        nwp = nwp.rename({"init_time": "init_time_utc"})
 
-    nwp = nwp.rename({"variable": "channel","init_time": "init_time_utc"})
     check_time_unique_increasing(nwp.init_time_utc)
     nwp = make_spatial_coords_increasing(nwp, x_coord="longitude", y_coord="latitude")
 


### PR DESCRIPTION
# Pull Request

## Description

Small changes to make gfs more flexible
This makes renaming from "init_time" to "init_time_utc" optional
Helps with #251 

## How Has This Been Tested?

- [x] CI tests
- [x] tested locally with
```
from ocf_data_sampler.load.nwp.providers.gfs import open_gfs
open_gfs('s3://ocf-open-data-pvnet/data/gfs/v4/2023.zarr')
```

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
