### PR TITLE
remove stored index pairs

### DIFF
--- a/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
+++ b/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
@@ -1,6 +1,5 @@
 """Torch dataset for UK PVNet."""
 
-import numpy as np
 import pandas as pd
 import xarray as xr
 from torch.utils.data import Dataset

--- a/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
+++ b/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
@@ -283,7 +283,10 @@ class PVNetUKRegionalDataset(AbstractPVNetUKDataset):
         if idx >= len(self):
             raise ValueError(f"Index {idx} out of range for dataset of length {len(self)}")
 
+        # t_index will be between 0 and len(self.valid_t0_times)-1
         t_index = idx % len(self.valid_t0_times)
+
+        # For each location, there are len(self.valid_t0_times) possible samples
         loc_index = idx // len(self.valid_t0_times)
 
         location = self.locations[loc_index]


### PR DESCRIPTION
# Pull Request

## Description

Currently in the UK regional dataset we have an attribute `index_pairs` which is an array of all of the possible (t0_index, location_index) pairs. This can be a very large array when training on a few years of data. I created a version of the dataset from 2019-2022 and this this array was 300MB! When we wrap the dataset in a pytorch DataLoader and use multiple workers this creates a copy of this index array in each worker. So for a typical 32 workers this can be 10GB of index pairs

Storing this index array was a design pattern copied across from `ocf_datapipes` and we actually don't need it here.

This PR removes the `index_pairs` array and calculates the values the values that would be in each index of `index_pairs` on the fly

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
