### PR TITLE
Adding public config in GSP for S3 bucket access

### DIFF
--- a/ocf_data_sampler/config/model.py
+++ b/ocf_data_sampler/config/model.py
@@ -291,6 +291,8 @@ class GSP(TimeWindowMixin, DropoutMixin):
         description="Version of the GSP boundaries to use. Options are '20220314' or '20250109'.",
     )
 
+    public: bool = Field(False, description="Whether the NWP data is public or private")
+
 
 class Site(TimeWindowMixin, DropoutMixin):
     """Site configuration model."""

--- a/ocf_data_sampler/load/gsp.py
+++ b/ocf_data_sampler/load/gsp.py
@@ -26,7 +26,7 @@ def get_gsp_boundaries(version: str) -> pd.DataFrame:
     )
 
 
-def open_gsp(zarr_path: str, boundaries_version: str = "20220314") -> xr.DataArray:
+def open_gsp(zarr_path: str, boundaries_version: str = "20220314", public: bool=False) -> xr.DataArray:
     """Open the GSP data.
 
     Args:
@@ -41,10 +41,17 @@ def open_gsp(zarr_path: str, boundaries_version: str = "20220314") -> xr.DataArr
     df_gsp_loc = get_gsp_boundaries(boundaries_version)
 
     # Open the GSP generation data
-    ds = (
+    if public:
+        ds = (
+        xr.open_dataset(zarr_path, engine='zarr', backend_kwargs={"storage_options":{"anon": True}})
+        .rename({"datetime_gmt": "time_utc"})
+    )
+    else:
+        ds = (
         xr.open_zarr(zarr_path)
         .rename({"datetime_gmt": "time_utc"})
     )
+    
 
     if not (ds.gsp_id.isin(df_gsp_loc.index)).all():
         raise ValueError(

--- a/ocf_data_sampler/load/load_dataset.py
+++ b/ocf_data_sampler/load/load_dataset.py
@@ -24,6 +24,7 @@ def get_dataset_dict(
         da_gsp = open_gsp(
             zarr_path=input_config.gsp.zarr_path,
             boundaries_version=input_config.gsp.boundaries_version,
+            public=input_config.gsp.public
         ).compute()
 
         if gsp_ids is None:


### PR DESCRIPTION
# Pull Request


It helps in **accessing gsp data** through S3 bucket publicly.


## How Has This Been Tested?

`PVNetUKRegionalDataset` function works with following config:

```
general:
  description: Configuration for GFS data sampling
  name: gfs_config

input_data:
  # # Either use Site OR GSP configuration
  # site:
  #   # Path to Site data in NetCDF format
  #   file_path: PLACEHOLDER.nc
  #   # Path to metadata in CSV format
  #   metadata_file_path: PLACEHOLDER.csv
  #   time_resolution_minutes: 15
  #   interval_start_minutes: -60
  #   # Specified for intraday currently
  #   interval_end_minutes: 480
  #   dropout_timedeltas_minutes: null
  #   dropout_fraction: 0 # Fraction of samples with dropout

  gsp:
    # Path to GSP data in zarr format
    # e.g. gs://solar-pv-nowcasting-data/PV/GSP/v7/pv_gsp.zarr
    zarr_path: "s3://ocf-open-data-pvnet/data/uk/pvlive/v1/target_data_2023_01.zarr"
    interval_start_minutes: -60
    # public: True
    # Specified for intraday currently
    interval_end_minutes: 480
    time_resolution_minutes: 30
    public: True
    # Random value from the list below will be chosen as the delay when dropout is used
    # If set to null no dropout is applied. Only values before t0 are dropped out for GSP.
    # Values after t0 are assumed as targets and cannot be dropped.
    dropout_timedeltas_minutes: []
    dropout_fraction: 0.0 # Fraction of samples with dropout

  nwp:
    gfs:
      time_resolution_minutes: 180 # Match the dataset's resolution (3 hours)
      interval_start_minutes: -180
      interval_end_minutes: 540
      dropout_fraction: 0.0
      dropout_timedeltas_minutes: []
      zarr_path: "s3://ocf-open-data-pvnet/data/gfs/v4/2023.zarr"
      provider: "gfs"
      image_size_pixels_height: 10
      image_size_pixels_width: 10
      public: True
      channels:
        - dlwrf # downwards long-wave radiation flux
        - dswrf # downwards short-wave radiation flux
        - hcc # high cloud cover
        - mcc # medium cloud cover
        - lcc # low cloud cover
        - prate # precipitation rate
        - r # relative humidity
        - t # 2-metre temperature
        - tcc # total cloud cover
        - u10 # 10-metre wind U component
        - u100 # 100-metre wind U component
        - v10 # 10-metre wind V component
        - v100 # 100-metre wind V component
        - vis # visibility
      normalisation_constants:
        dlwrf:
          mean: 298.342
          std: 96.305916
        dswrf:
          mean: 168.12321
          std: 246.18533
        hcc:
          mean: 35.272
          std: 42.525383
        lcc:
          mean: 43.578342
          std: 44.3732
        mcc:
          mean: 33.738823
          std: 43.150745
        prate:
          mean: 2.8190969e-05
          std: 0.00010159573
        r:
          mean: 18.359747
          std: 25.440672
        sde:
          mean: 0.36937004
          std: 0.43345627
        t:
          mean: 278.5223
          std: 22.825893
        tcc:
          mean: 66.841606
          std: 41.030598
        u10:
          mean: -0.0022310058
          std: 5.470838
        u100:
          mean: 0.0823025
          std: 6.8899174
        v10:
          mean: 0.06219831
          std: 4.7401133
        v100:
          mean: 0.0797807
          std: 6.076132
        vis:
          mean: 19628.32
          std: 8294.022
        u:
          mean: 11.645444
          std: 10.614556
        v:
          mean: 0.12330122
          std: 7.176398

```

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
