### PR TITLE
Improved Error Message

### DIFF
--- a/ocf_data_sampler/select/select_spatial_slice.py
+++ b/ocf_data_sampler/select/select_spatial_slice.py
@@ -239,8 +239,19 @@ def select_spatial_slice_pixels(
         if allow_partial_slice:
             da = _select_padded_slice(da, left_idx, right_idx, bottom_idx, top_idx, x_dim, y_dim)
         else:
+            issues = []
+            if left_idx < 0:
+                issues.append(f"left_idx ({left_idx}) < 0")
+            if right_idx > data_width_pixels:
+                issues.append(f"right_idx ({right_idx}) > data_width_pixels ({data_width_pixels})")
+            if bottom_idx < 0:
+                issues.append(f"bottom_idx ({bottom_idx}) < 0")
+            if top_idx > data_height_pixels:
+                issues.append(f"top_idx ({top_idx}) > data_height_pixels ({data_height_pixels})")
+            issue_details = "\n".join(issues)
             raise ValueError(
-                f"Window for location {location} not available.  Padding required. "
+                f"Window for location {location} not available.  Padding required due to: \n"
+                f"{issue_details}\n"
                 "You may wish to set `allow_partial_slice=True`",
             )
     else:

--- a/tests/select/test_select_spatial_slice.py
+++ b/tests/select/test_select_spatial_slice.py
@@ -147,7 +147,7 @@ def test_select_spatial_slice_pixels(da):
 
 def test_select_spatial_slice_pixels_no_partial(da):
     """Test that ValueError is raised when allow_partial_slice=False and padding is needed."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         select_spatial_slice_pixels(
             da,
             location=Location(x=-90, y=-80, coordinate_system="osgb"),
@@ -155,8 +155,11 @@ def test_select_spatial_slice_pixels_no_partial(da):
             height_pixels=30,
             allow_partial_slice=False,
         )
+    msg = str(excinfo.value)
+    assert "Padding required" in msg
+    assert "left_idx" in msg or "bottom_idx" in msg or "right_idx" in msg or "top_idx" in msg
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         select_spatial_slice_pixels(
             da,
             location=Location(x=90, y=90, coordinate_system="osgb"),
@@ -164,3 +167,6 @@ def test_select_spatial_slice_pixels_no_partial(da):
             height_pixels=40,
             allow_partial_slice=False,
         )
+    msg = str(excinfo.value)
+    assert "Padding required" in msg
+    assert "left_idx" in msg or "bottom_idx" in msg or "right_idx" in msg or "top_idx" in msg


### PR DESCRIPTION
# Pull Request

## Description
I try to improved the ValueError message when padding is required by including detailed index variables  like (left_idx, right_idx). This helps users understand why padding is needed.

Fixes #266

## How Has This Been Tested?
- Tested using pytest.

**Proof of Test**
>![Screenshot from 2025-05-29 14-38-57](https://github.com/user-attachments/assets/81feb256-3cd5-4880-89e6-9ca21cfa2d61)

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
