### PR TITLE
More robust create site data

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -390,10 +390,6 @@ def create_site_data(
 
 @pytest.fixture(scope="session")
 def data_sites(session_tmp_path):
-    """
-    Make fake data for sites using the robust creation function.
-    Returns: filename for netcdf file, and csv metadata
-    """
     return create_site_data(tmp_path_base=session_tmp_path)
 
 


### PR DESCRIPTION
Precursor to introducing dedicated site specific config for testing purposes and updating / expanding relevant tests:

- create_site_data function - logic for generating site data extracted from data_sites fixture.
- Parameterised data generation: function accepts arguments.
- Reduced hardcoded params: now params of create_site_data function.
- Unique names for NetCDF ensured by hashing the input params - improves testing overall pretty much.
- data_sites fixture slimmed down.