### PR TITLE
Remove time feature prefix

### DIFF
--- a/ocf_data_sampler/numpy_sample/__init__.py
+++ b/ocf_data_sampler/numpy_sample/__init__.py
@@ -1,6 +1,6 @@
 """Conversion from Xarray to NumpySample"""
 
-from .datetime_features import make_datetime_numpy_dict
+from .datetime_features import encode_datetimes
 from .gsp import convert_gsp_to_numpy_sample, GSPSampleKey
 from .nwp import convert_nwp_to_numpy_sample, NWPSampleKey
 from .satellite import convert_satellite_to_numpy_sample, SatelliteSampleKey

--- a/ocf_data_sampler/numpy_sample/datetime_features.py
+++ b/ocf_data_sampler/numpy_sample/datetime_features.py
@@ -6,18 +6,15 @@ import pandas as pd
 from ocf_data_sampler.numpy_sample.common_types import NumpySample
 
 
-
-
 def encode_datetimes(datetimes: pd.DatetimeIndex) -> NumpySample:
     """Creates dictionary of sin and cos datetime embeddings.
-    
+
     Args:
-        dt: DatetimeIndex to create radian embeddings for
+        datetimes: DatetimeIndex to create radian embeddings for
 
     Returns:
         Dictionary of datetime encodings
     """
-
     day_of_year = datetimes.dayofyear
     minute_of_day = datetimes.minute + datetimes.hour * 60
 

--- a/ocf_data_sampler/numpy_sample/datetime_features.py
+++ b/ocf_data_sampler/numpy_sample/datetime_features.py
@@ -6,33 +6,27 @@ import pandas as pd
 from ocf_data_sampler.numpy_sample.common_types import NumpySample
 
 
-def _get_date_time_in_pi(dt: pd.DatetimeIndex) -> tuple[np.ndarray, np.ndarray]:
-    """Create positional embeddings for the datetimes in radians.
 
+
+def encode_datetimes(datetimes: pd.DatetimeIndex) -> NumpySample:
+    """Creates dictionary of sin and cos datetime embeddings.
+    
     Args:
         dt: DatetimeIndex to create radian embeddings for
 
     Returns:
-        Tuple of numpy arrays containing radian coordinates for date and time
+        Dictionary of datetime encodings
     """
-    day_of_year = dt.dayofyear
-    minute_of_day = dt.minute + dt.hour * 60
 
-    time_in_pi = (2 * np.pi) * (minute_of_day / (24 * 60))
-    date_in_pi = (2 * np.pi) * (day_of_year / 365)
+    day_of_year = datetimes.dayofyear
+    minute_of_day = datetimes.minute + datetimes.hour * 60
 
-    return date_in_pi, time_in_pi
+    time_in_radians = (2 * np.pi) * (minute_of_day / (24 * 60))
+    date_in_radians = (2 * np.pi) * (day_of_year / 365)
 
-
-def make_datetime_numpy_dict(datetimes: pd.DatetimeIndex, key_prefix: str = "wind") -> NumpySample:
-    """Creates dictionary of cyclical datetime features - encoded."""
-    date_in_pi, time_in_pi = _get_date_time_in_pi(datetimes)
-
-    time_numpy_sample = {}
-
-    time_numpy_sample[key_prefix + "_date_sin"] = np.sin(date_in_pi)
-    time_numpy_sample[key_prefix + "_date_cos"] = np.cos(date_in_pi)
-    time_numpy_sample[key_prefix + "_time_sin"] = np.sin(time_in_pi)
-    time_numpy_sample[key_prefix + "_time_cos"] = np.cos(time_in_pi)
-
-    return time_numpy_sample
+    return {
+        "date_sin": np.sin(date_in_radians),
+        "date_cos": np.cos(date_in_radians),
+        "time_sin": np.sin(time_in_radians),
+        "time_cos": np.cos(time_in_radians),
+    }

--- a/ocf_data_sampler/numpy_sample/site.py
+++ b/ocf_data_sampler/numpy_sample/site.py
@@ -13,10 +13,7 @@ class SiteSampleKey:
     time_utc = "site_time_utc"
     t0_idx = "site_t0_idx"
     id = "site_id"
-    date_sin = "site_date_sin"
-    date_cos = "site_date_cos"
-    time_sin = "site_time_sin"
-    time_cos = "site_time_cos"
+
 
 
 def convert_site_to_numpy_sample(da: xr.DataArray, t0_idx: int | None = None) -> NumpySample:
@@ -31,10 +28,6 @@ def convert_site_to_numpy_sample(da: xr.DataArray, t0_idx: int | None = None) ->
         SiteSampleKey.capacity_kwp: da.isel(time_utc=0)["capacity_kwp"].values,
         SiteSampleKey.time_utc: da["time_utc"].values.astype(float),
         SiteSampleKey.id: da["site_id"].values,
-        SiteSampleKey.date_sin: da["date_sin"].values,
-        SiteSampleKey.date_cos: da["date_cos"].values,
-        SiteSampleKey.time_sin: da["time_sin"].values,
-        SiteSampleKey.time_cos: da["time_cos"].values,
     }
 
     if t0_idx is not None:

--- a/tests/numpy_sample/test_datetime_features.py
+++ b/tests/numpy_sample/test_datetime_features.py
@@ -1,35 +1,23 @@
 import numpy as np
 import pandas as pd
 
-from ocf_data_sampler.numpy_sample.datetime_features import make_datetime_numpy_dict
+from ocf_data_sampler.numpy_sample.datetime_features import encode_datetimes
 
 
-def test_calculate_azimuth_and_elevation():
+def test_encode_datetimes():
     # Pick the day of the summer solstice
     datetimes = pd.to_datetime(["2024-06-20 12:00", "2024-06-20 12:30", "2024-06-20 13:00"])
 
-    # Calculate sun angles
-    datetime_features = make_datetime_numpy_dict(datetimes)
+    # Calculate datetime encoding features
+    datetime_features = encode_datetimes(datetimes)
 
     assert len(datetime_features) == 4
 
-    assert len(datetime_features["wind_date_sin"]) == len(datetimes)
-    assert (datetime_features["wind_date_cos"] != datetime_features["wind_date_sin"]).all()
+    assert len(datetime_features["date_sin"]) == len(datetimes)
+    assert (datetime_features["date_cos"] != datetime_features["date_sin"]).all()
 
     # assert all values are between -1 and 1
-    assert all(np.abs(datetime_features["wind_date_sin"]) <= 1)
-    assert all(np.abs(datetime_features["wind_date_cos"]) <= 1)
-    assert all(np.abs(datetime_features["wind_time_sin"]) <= 1)
-    assert all(np.abs(datetime_features["wind_time_cos"]) <= 1)
-
-
-def test_make_datetime_numpy_batch_custom_key_prefix():
-    # Test function correctly applies custom prefix to dict keys
-    datetimes = pd.to_datetime(["2024-06-20 12:00", "2024-06-20 12:30", "2024-06-20 13:00"])
-    key_prefix = "solar"
-
-    datetime_features = make_datetime_numpy_dict(datetimes, key_prefix=key_prefix)
-
-    # Assert dict contains expected quantity of keys and verify starting with custom prefix
-    assert len(datetime_features) == 4
-    assert all(key.startswith(key_prefix) for key in datetime_features)
+    assert all(np.abs(datetime_features["date_sin"]) <= 1)
+    assert all(np.abs(datetime_features["date_cos"]) <= 1)
+    assert all(np.abs(datetime_features["time_sin"]) <= 1)
+    assert all(np.abs(datetime_features["time_cos"]) <= 1)

--- a/tests/torch_datasets/test_site.py
+++ b/tests/torch_datasets/test_site.py
@@ -40,10 +40,10 @@ def test_site(tmp_path, site_config_filename):
     }
 
     expected_coords_subset = {
-        "site__date_cos",
-        "site__time_cos",
-        "site__time_sin",
-        "site__date_sin",
+        "date_cos",
+        "time_cos",
+        "time_sin",
+        "date_sin",
         "solar_azimuth",
         "solar_elevation",
     }
@@ -131,10 +131,10 @@ def test_site_dataset_with_dataloader(sites_dataset) -> None:
     assert individual_xr_sample["site"].values.shape == (4,) # CORRECTED: Changed from (7,) to (4,)
 
     expected_coords_subset = {
-        "site__date_cos",
-        "site__time_cos",
-        "site__time_sin",
-        "site__date_sin",
+        "date_cos",
+        "time_cos",
+        "time_sin",
+        "date_sin",
         "solar_azimuth",
         "solar_elevation",
     }


### PR DESCRIPTION
# Pull Request

## Description

Solves #159 

Removes the source prefix from the datetime encodings. This will require an update in PVNet as well - so this should be a minor bump

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
