### PR TITLE
Improve Validation Logic for Dropout Fraction in `DropoutMixin`

### DIFF
--- a/ocf_data_sampler/config/model.py
+++ b/ocf_data_sampler/config/model.py
@@ -146,6 +146,22 @@ class DropoutMixin(Base):
         return self
 
 
+    @model_validator(mode="after")
+    def validate_dropout(self) -> "DropoutMixin":
+        """Validator for dropout instructions."""
+        if isinstance(self.dropout_fraction, float):
+            if self.dropout_fraction > 0 and self.dropout_timedeltas_minutes:
+                raise ValueError(
+                    "If dropout_fraction is a float, dropout_timedeltas_minutes must be empty."
+                )
+        elif isinstance(self.dropout_fraction, list):
+            if len(self.dropout_fraction) != len(self.dropout_timedeltas_minutes):
+                raise ValueError(
+                    "If dropout_fraction is a list, its length must match dropout_timedeltas_minutes."
+                )
+        return self
+
+
 class SpatialWindowMixin(Base):
     """Mixin class, to add path and image size."""
 


### PR DESCRIPTION
### **Pull Request**
## **Description**
This PR improves the validation logic for the `dropout_fraction` field in the `DropoutMixin` class. The current implementation allows `dropout_fraction` to accept both a `float` and a `list[float]`, which introduces ambiguity and complexity in validation. 
The updated logic ensures:
- If `dropout_fraction` is a `float`, `dropout_timedeltas_minutes` must be empty.
- If `dropout_fraction` is a `list[float]`, its length must match the length of `dropout_timedeltas_minutes`.
Let me know if you need further improvements!