### PR TITLE
More lenient attr merging

### DIFF
--- a/ocf_data_sampler/load/open_xarray_tensorstore.py
+++ b/ocf_data_sampler/load/open_xarray_tensorstore.py
@@ -148,7 +148,7 @@ def open_zarrs(
         dim=concat_dim,
         data_vars="minimal",
         compat="equals",
-        combine_attrs="no_conflicts",
+        combine_attrs="drop_conflicts",
     )
 
     if mask_and_scale:


### PR DESCRIPTION
Change the way we merge attrs. The previous one was a little too strict as some of the non-important attrs in our different satellite datasets don't match. E.g. there is an attr which corresponds to the valid time, and is different for all of the sat datasets. We don't use these attrs