### PR TITLE
Add async reading of tensorstore dataarrays

### DIFF
--- a/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
+++ b/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
@@ -30,7 +30,7 @@ from ocf_data_sampler.torch_datasets.utils.merge_and_fill_utils import (
     fill_nans_in_arrays,
     merge_dicts,
 )
-from ocf_data_sampler.utils import compute, minutes
+from ocf_data_sampler.utils import minutes, tensorstore_compute
 
 xr.set_options(keep_attrs=True)
 
@@ -254,7 +254,7 @@ class PVNetUKRegionalDataset(AbstractPVNetUKDataset):
         """
         sample_dict = slice_datasets_by_space(self.datasets_dict, location, self.config)
         sample_dict = slice_datasets_by_time(sample_dict, t0, self.config)
-        sample_dict = compute(sample_dict)
+        sample_dict = tensorstore_compute(sample_dict)
 
         return self.process_and_combine_datasets(sample_dict, t0, location)
 
@@ -313,7 +313,7 @@ class PVNetUKConcurrentDataset(AbstractPVNetUKDataset):
         """
         # Slice by time then load to avoid loading the data multiple times from disk
         sample_dict = slice_datasets_by_time(self.datasets_dict, t0, self.config)
-        sample_dict = compute(sample_dict)
+        sample_dict = tensorstore_compute(sample_dict)
 
         gsp_samples = []
 

--- a/ocf_data_sampler/torch_datasets/datasets/site.py
+++ b/ocf_data_sampler/torch_datasets/datasets/site.py
@@ -34,7 +34,7 @@ from ocf_data_sampler.torch_datasets.utils.merge_and_fill_utils import (
     fill_nans_in_arrays,
     merge_dicts,
 )
-from ocf_data_sampler.utils import compute, minutes
+from ocf_data_sampler.utils import minutes, tensorstore_compute
 
 xr.set_options(keep_attrs=True)
 
@@ -272,7 +272,7 @@ class SitesDataset(Dataset):
         sample_dict = slice_datasets_by_space(self.datasets_dict, location, self.config)
         sample_dict = slice_datasets_by_time(sample_dict, t0, self.config)
 
-        sample_dict = compute(sample_dict)
+        sample_dict = tensorstore_compute(sample_dict)
 
         return process_and_combine_datasets(
             sample_dict,
@@ -408,7 +408,7 @@ class SitesDatasetConcurrent(Dataset):
         """
         # slice by time first as we want to keep all site id info
         sample_dict = slice_datasets_by_time(self.datasets_dict, t0, self.config)
-        sample_dict = compute(sample_dict)
+        sample_dict = tensorstore_compute(sample_dict)
 
         site_samples = []
 

--- a/ocf_data_sampler/utils.py
+++ b/ocf_data_sampler/utils.py
@@ -1,6 +1,7 @@
 """Miscellaneous helper functions."""
 
 import pandas as pd
+from xarray_tensorstore import read
 
 
 def minutes(minutes: int | list[float]) -> pd.Timedelta | pd.TimedeltaIndex:
@@ -11,11 +12,26 @@ def minutes(minutes: int | list[float]) -> pd.Timedelta | pd.TimedeltaIndex:
     """
     return pd.to_timedelta(minutes, unit="m")
 
+
 def compute(xarray_dict: dict) -> dict:
     """Eagerly load a nested dictionary of xarray DataArrays."""
     for k, v in xarray_dict.items():
         if isinstance(v, dict):
             xarray_dict[k] = compute(v)
         else:
-            xarray_dict[k] = v.compute(scheduler="single-threaded")
+            xarray_dict[k] = v.compute()
     return xarray_dict
+
+
+def tensorstore_compute(xarray_dict: dict) -> dict:
+    """Eagerly read and load a nested dictionary of xarray-tensorstore DataArrays."""
+    # Kick off the tensorstore async reading
+    for k, v in xarray_dict.items():
+        if isinstance(v, dict):
+            xarray_dict[k] = tensorstore_compute(v)
+        else:
+            xarray_dict[k] = read(v)
+
+    # Running the compute function will wait until all arrays have been read
+    return compute(xarray_dict)
+

--- a/tests/torch_datasets/test_pvnet_uk.py
+++ b/tests/torch_datasets/test_pvnet_uk.py
@@ -1,7 +1,5 @@
-import dask.array
 import numpy as np
 import torch
-import xarray as xr
 from torch.utils.data import DataLoader
 
 from ocf_data_sampler.config import load_yaml_configuration, save_yaml_configuration
@@ -9,27 +7,7 @@ from ocf_data_sampler.config.model import SolarPosition
 from ocf_data_sampler.torch_datasets.datasets.pvnet_uk import (
     PVNetUKConcurrentDataset,
     PVNetUKRegionalDataset,
-    compute,
 )
-
-
-def test_compute():
-    """Test compute function with dask array"""
-    da_dask = xr.DataArray(dask.array.random.random((5, 5)))
-
-    # Create a nested dictionary with dask array
-    lazy_data_dict = {
-        "array1": da_dask,
-        "nested": {
-            "array2": da_dask,
-        },
-    }
-
-    computed_data_dict = compute(lazy_data_dict)
-
-    # Assert that the result is no longer lazy
-    assert isinstance(computed_data_dict["array1"].data, np.ndarray)
-    assert isinstance(computed_data_dict["nested"]["array2"].data, np.ndarray)
 
 
 def test_pvnet_uk_regional_dataset(pvnet_config_filename):


### PR DESCRIPTION
# Pull Request

## Description

This PR adds async reading of tensorstore arrays. Previously we were loading the data from each of the input datasets sequentially. Using xarray-tensorstore we can load them simultaneously, and this is the [recommendation in xarray-tensorstore itself](https://github.com/google/xarray-tensorstore?tab=readme-ov-file#usage). 

In some local tests I did on donatello, using ECMWF, UKV, satellite and cloudcasting inputs (i.e. a lot of inputs) this sped up the time to create a PVNet UK regional sample by around 20% in my case. 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
