### PR TITLE
(Speed-up) Assume spatial coords are sorted

### DIFF
--- a/ocf_data_sampler/select/select_spatial_slice.py
+++ b/ocf_data_sampler/select/select_spatial_slice.py
@@ -25,13 +25,13 @@ def _get_pixel_index_location(da: xr.DataArray, location: Location) -> tuple[int
     x, y = location.in_coord_system(target_coords)
 
     # Check that requested point lies within the data
-    if not (da[x_dim].min() < x < da[x_dim].max()):
+    if not (da[x_dim].values[0] < x < da[x_dim].values[-1]):
         raise ValueError(
-            f"{x} is not in the interval {da[x_dim].min().values}: {da[x_dim].max().values}",
+            f"{x} is not in the interval {da[x_dim].values[0]}: {da[x_dim].values[-1]}",
         )
-    if not (da[y_dim].min() < y < da[y_dim].max()):
+    if not (da[y_dim].values[0] < y < da[y_dim].values[-1]):
         raise ValueError(
-            f"{y} is not in the interval {da[y_dim].min().values}: {da[y_dim].max().values}",
+            f"{y} is not in the interval {da[y_dim].values[0]}: {da[y_dim].values[-1]}",
         )
 
     x_index = da.get_index(x_dim)


### PR DESCRIPTION
# Pull Request

## Description

Doing mins and maxes across the spatial coords is slow. In the load functions we make sure that the spatial coordinates are sorted in increasing order using [this function](https://github.com/openclimatefix/ocf-data-sampler/blob/main/ocf_data_sampler/load/utils.py#L15). We can make use of this to index the right values instead of doing mins and maxes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
