### PR TITLE
(Speed-up) Minimise GSP loading

### DIFF
--- a/ocf_data_sampler/load/gsp.py
+++ b/ocf_data_sampler/load/gsp.py
@@ -71,7 +71,6 @@ def open_gsp(
     ds = ds.assign_coords(
         x_osgb=(df_gsp_loc.x_osgb.to_xarray()),
         y_osgb=(df_gsp_loc.y_osgb.to_xarray()),
-        nominal_capacity_mwp=ds.installedcapacity_mwp,
         effective_capacity_mwp=ds.capacity_mwp,
     )
 
@@ -84,7 +83,6 @@ def open_gsp(
     coord_dtypes = {
         "time_utc": np.datetime64,
         "gsp_id": np.integer,
-        "nominal_capacity_mwp": np.floating,
         "effective_capacity_mwp": np.floating,
         "x_osgb": np.floating,
         "y_osgb": np.floating,

--- a/ocf_data_sampler/numpy_sample/gsp.py
+++ b/ocf_data_sampler/numpy_sample/gsp.py
@@ -9,7 +9,6 @@ class GSPSampleKey:
     """Keys for the GSP sample dictionary."""
 
     gsp = "gsp"
-    nominal_capacity_mwp = "gsp_nominal_capacity_mwp"
     effective_capacity_mwp = "gsp_effective_capacity_mwp"
     time_utc = "gsp_time_utc"
     t0_idx = "gsp_t0_idx"

--- a/ocf_data_sampler/numpy_sample/gsp.py
+++ b/ocf_data_sampler/numpy_sample/gsp.py
@@ -27,8 +27,7 @@ def convert_gsp_to_numpy_sample(da: xr.DataArray, t0_idx: int | None = None) -> 
     """
     sample = {
         GSPSampleKey.gsp: da.values,
-        GSPSampleKey.nominal_capacity_mwp: da.isel(time_utc=0)["nominal_capacity_mwp"].values,
-        GSPSampleKey.effective_capacity_mwp: da.isel(time_utc=0)["effective_capacity_mwp"].values,
+        GSPSampleKey.effective_capacity_mwp: da.effective_capacity_mwp.values[0],
         GSPSampleKey.time_utc: da["time_utc"].values.astype(float),
     }
 

--- a/tests/load/test_load_gsp.py
+++ b/tests/load/test_load_gsp.py
@@ -28,7 +28,6 @@ def test_open_gsp(uk_gsp_zarr_path):
     assert isinstance(da, xr.DataArray)
     assert da.dims == ("time_utc", "gsp_id")
 
-    assert "nominal_capacity_mwp" in da.coords
     assert "effective_capacity_mwp" in da.coords
     assert "x_osgb" in da.coords
     assert "y_osgb" in da.coords
@@ -46,7 +45,6 @@ def test_open_gsp_bad_dtype(tmp_path: Path):
     bad_ds = xr.Dataset(
         data_vars={
             "generation_mw": (("datetime_gmt", "gsp_id"), np.random.randint(0, 100, (10, 2))),
-            "installedcapacity_mwp": (("gsp_id",), [100.0, 120.0]),
             "capacity_mwp": (("gsp_id",), [90.0, 110.0]),
         },
         coords={

--- a/tests/numpy_sample/test_gsp.py
+++ b/tests/numpy_sample/test_gsp.py
@@ -14,7 +14,6 @@ def test_convert_gsp_to_numpy_sample(uk_gsp_zarr_path):
     assert set(numpy_sample.keys()).issubset(
         {
             GSPSampleKey.gsp,
-            GSPSampleKey.nominal_capacity_mwp,
             GSPSampleKey.effective_capacity_mwp,
             GSPSampleKey.time_utc,
         },
@@ -27,10 +26,6 @@ def test_convert_gsp_to_numpy_sample(uk_gsp_zarr_path):
         np.ndarray,
     ), "Time UTC should be numpy array"
     assert numpy_sample[GSPSampleKey.time_utc].dtype == float, "Time UTC should be float type"
-    assert (
-        numpy_sample[GSPSampleKey.nominal_capacity_mwp]
-        == da.isel(time_utc=0)["nominal_capacity_mwp"].values
-    )
     assert (
         numpy_sample[GSPSampleKey.effective_capacity_mwp]
         == da.isel(time_utc=0)["effective_capacity_mwp"].values


### PR DESCRIPTION
# Pull Request

## Description

This is two separate items

1. We don't use the nominal capacity anymore. That is a legacy thing and we proved using it was the wrong choice.
2.  Instead of using `isel()` we can index directly into the numpy array. This is faster

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
