### PR TITLE
(Speed-up) Avoid xarray for normalisation constants

### DIFF
--- a/ocf_data_sampler/config/model.py
+++ b/ocf_data_sampler/config/model.py
@@ -172,23 +172,6 @@ class NormalisationConstantsMixin(Base):
     """Normalisation constants for multiple channels."""
     normalisation_constants: dict[str, NormalisationValues]
 
-    @property
-    def channel_means(self) -> dict[str, float]:
-        """Return the channel means."""
-        return {
-            channel: norm_values.mean
-            for channel, norm_values in self.normalisation_constants.items()
-        }
-
-
-    @property
-    def channel_stds(self) -> dict[str, float]:
-        """Return the channel standard deviations."""
-        return {
-            channel: norm_values.std
-            for channel, norm_values in self.normalisation_constants.items()
-        }
-
 
 class Satellite(TimeWindowMixin, DropoutMixin, SpatialWindowMixin, NormalisationConstantsMixin):
     """Satellite configuration model."""

--- a/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
+++ b/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
@@ -151,17 +151,19 @@ class AbstractPVNetUKDataset(Dataset):
             da_sat = dataset_dict["sat"]
 
             # Standardise and convert to NumpyBatch
-            da_channel_means = self.means_dict["sat"]
-            da_channel_stds = self.stds_dict["sat"]
+            channel_means = self.means_dict["sat"].values[None, :, None, None]
+            dchannel_stds = self.stds_dict["sat"].values[None, :, None, None]
 
-            da_sat = (da_sat - da_channel_means) / da_channel_stds
+            #da_sat = (da_sat - da_channel_means) / da_channel_stds
+
+            da_sat = (da_sat - channel_means) / dchannel_stds
 
             numpy_modalities.append(convert_satellite_to_numpy_sample(da_sat))
 
         if "gsp" in dataset_dict:
             gsp_config = self.config.input_data.gsp
             da_gsp = dataset_dict["gsp"]
-            da_gsp = da_gsp / da_gsp.effective_capacity_mwp
+            da_gsp = da_gsp / da_gsp.effective_capacity_mwp.values
 
             # Convert to NumpyBatch
             numpy_modalities.append(

--- a/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
+++ b/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
@@ -137,10 +137,10 @@ class AbstractPVNetUKDataset(Dataset):
             for nwp_key, da_nwp in dataset_dict["nwp"].items():
 
                 # Standardise and convert to NumpyBatch
-                da_channel_means = self.means_dict["nwp"][nwp_key]
-                da_channel_stds = self.stds_dict["nwp"][nwp_key]
+                channel_means = self.means_dict["nwp"][nwp_key]
+                channel_stds = self.stds_dict["nwp"][nwp_key]
 
-                da_nwp = (da_nwp - da_channel_means) / da_channel_stds
+                da_nwp = (da_nwp - channel_means) / channel_stds
 
                 nwp_numpy_modalities[nwp_key] = convert_nwp_to_numpy_sample(da_nwp)
 
@@ -151,12 +151,10 @@ class AbstractPVNetUKDataset(Dataset):
             da_sat = dataset_dict["sat"]
 
             # Standardise and convert to NumpyBatch
-            channel_means = self.means_dict["sat"].values[None, :, None, None]
-            dchannel_stds = self.stds_dict["sat"].values[None, :, None, None]
+            channel_means = self.means_dict["sat"]
+            channel_stds = self.stds_dict["sat"]
 
-            #da_sat = (da_sat - da_channel_means) / da_channel_stds
-
-            da_sat = (da_sat - channel_means) / dchannel_stds
+            da_sat = (da_sat - channel_means) / channel_stds
 
             numpy_modalities.append(convert_satellite_to_numpy_sample(da_sat))
 

--- a/ocf_data_sampler/torch_datasets/datasets/site.py
+++ b/ocf_data_sampler/torch_datasets/datasets/site.py
@@ -82,10 +82,10 @@ def process_and_combine_datasets(
 
             # Standardise and convert to NumpyBatch
 
-            da_channel_means = means_dict["nwp"][nwp_key]
-            da_channel_stds = stds_dict["nwp"][nwp_key]
+            channel_means = means_dict["nwp"][nwp_key]
+            channel_stds = stds_dict["nwp"][nwp_key]
 
-            da_nwp = (da_nwp - da_channel_means) / da_channel_stds
+            da_nwp = (da_nwp - channel_means) / channel_stds
 
             nwp_numpy_modalities[nwp_key] = convert_nwp_to_numpy_sample(da_nwp)
 
@@ -96,16 +96,16 @@ def process_and_combine_datasets(
         da_sat = dataset_dict["sat"]
 
         # Standardise and convert to NumpyBatch
-        da_channel_means = means_dict["sat"]
-        da_channel_stds = stds_dict["sat"]
+        channel_means = means_dict["sat"]
+        channel_stds = stds_dict["sat"]
 
-        da_sat = (da_sat - da_channel_means) / da_channel_stds
+        da_sat = (da_sat - channel_means) / channel_stds
 
         numpy_modalities.append(convert_satellite_to_numpy_sample(da_sat))
 
     if "site" in dataset_dict:
         da_sites = dataset_dict["site"]
-        da_sites = da_sites / da_sites.capacity_kwp
+        da_sites = da_sites / da_sites.capacity_kwp.values
 
         # Convert to NumpyBatch
         numpy_modalities.append(convert_site_to_numpy_sample(da_sites))

--- a/ocf_data_sampler/torch_datasets/utils/config_normalization_values_to_dicts.py
+++ b/ocf_data_sampler/torch_datasets/utils/config_normalization_values_to_dicts.py
@@ -50,7 +50,7 @@ def config_normalization_values_to_dicts(
                 # These accumulated channels are diffed and renamed
                 if channel in nwp_config.accum_channels:
                     channel =f"diff_{channel}"
-                
+
                 means_list.append(nwp_config.normalisation_constants[channel].mean)
                 stds_list.append(nwp_config.normalisation_constants[channel].std)
 
@@ -62,7 +62,7 @@ def config_normalization_values_to_dicts(
 
         means_list = []
         stds_list = []
-        
+
         for channel in list(config.input_data.satellite.channels):
             means_list.append(sat_config.normalisation_constants[channel].mean)
             stds_list.append(sat_config.normalisation_constants[channel].std)

--- a/ocf_data_sampler/torch_datasets/utils/config_normalization_values_to_dicts.py
+++ b/ocf_data_sampler/torch_datasets/utils/config_normalization_values_to_dicts.py
@@ -1,6 +1,7 @@
 """Utility function for converting normalisation constants in the config to arrays."""
 
 import numpy as np
+
 from ocf_data_sampler.config import Configuration
 
 

--- a/ocf_data_sampler/torch_datasets/utils/config_normalization_values_to_dicts.py
+++ b/ocf_data_sampler/torch_datasets/utils/config_normalization_values_to_dicts.py
@@ -1,24 +1,8 @@
-"""Utility function for converting channel dictionaries to xarray DataArrays."""
+"""Utility function for converting normalisation constants in the config to arrays."""
 
 import numpy as np
-import xarray as xr
-
 from ocf_data_sampler.config import Configuration
 
-
-def channel_dict_to_dataarray(channel_dict: dict[str, float]) -> xr.DataArray:
-    """Converts a dictionary of channel values to a DataArray.
-
-    Args:
-        channel_dict: Dictionary mapping channel names (str) to their values (float).
-
-    Returns:
-        xr.DataArray: A 1D DataArray with channels as coordinates.
-    """
-    return xr.DataArray(
-        list(channel_dict.values()),
-        coords={"channel": list(channel_dict.keys())},
-    )
 
 def config_normalization_values_to_dicts(
     config: Configuration,
@@ -54,8 +38,8 @@ def config_normalization_values_to_dicts(
                 means_list.append(nwp_config.normalisation_constants[channel].mean)
                 stds_list.append(nwp_config.normalisation_constants[channel].std)
 
-            means_dict["nwp"][nwp_key] = np.array(means_list)
-            stds_dict["nwp"][nwp_key] = np.array(stds_list)
+            means_dict["nwp"][nwp_key] = np.array(means_list)[None, :, None, None]
+            stds_dict["nwp"][nwp_key] = np.array(stds_list)[None, :, None, None]
 
     if config.input_data.satellite is not None:
         sat_config = config.input_data.satellite


### PR DESCRIPTION
# Pull Request

## Description

Change from using xarray DataArrays for the normalisation to numpy arrays


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
