### PR TITLE
Bug recursion order

### DIFF
--- a/ocf_data_sampler/utils.py
+++ b/ocf_data_sampler/utils.py
@@ -23,15 +23,18 @@ def compute(xarray_dict: dict) -> dict:
     return xarray_dict
 
 
-def tensorstore_compute(xarray_dict: dict) -> dict:
-    """Eagerly read and load a nested dictionary of xarray-tensorstore DataArrays."""
+def tensorstore_read(xarray_dict: dict) -> dict:
+    """Start reading a nested dictionary of xarray-tensorstore DataArrays."""
     # Kick off the tensorstore async reading
     for k, v in xarray_dict.items():
         if isinstance(v, dict):
-            xarray_dict[k] = tensorstore_compute(v)
+            xarray_dict[k] = tensorstore_read(v)
         else:
             xarray_dict[k] = read(v)
+    return xarray_dict
 
-    # Running the compute function will wait until all arrays have been read
-    return compute(xarray_dict)
+
+def tensorstore_compute(xarray_dict: dict) -> dict:
+    """Eagerly read and load a nested dictionary of xarray-tensorstore DataArrays."""
+    return compute(tensorstore_read(xarray_dict))
 


### PR DESCRIPTION
# Pull Request

## Description

There was a bug in the `tensorstore_compute()` function introduced in #311. The intended behaviour was that we would start reading all the datasets to take advantage of tensorstore's async loading and then compute them all. Due to the recursion in that function we were actually reading and computing some of the datasets, then reading and computing others. This is inefficient. This PR corrects the behaviour

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
