### PR TITLE
Speed up compute order

### DIFF
--- a/ocf_data_sampler/utils.py
+++ b/ocf_data_sampler/utils.py
@@ -15,15 +15,14 @@ def minutes(minutes: int | list[float]) -> pd.Timedelta | pd.TimedeltaIndex:
 
 def compute(xarray_dict: dict) -> dict:
     """Eagerly load a nested dictionary of xarray DataArrays."""
-    
     # Load these keys first because they don't use tensorstore
     priority_keys = ["gsp", "site"]
     for key in priority_keys:
-        if key in xarray_dict:            
+        if key in xarray_dict:
             xarray_dict[key] = xarray_dict[key].compute()
 
-    # Load the rest
-    keys = [k for k in xarray_dict.keys() if k not in priority_keys]
+    # Load the rest
+    keys = [k for k in xarray_dict if k not in priority_keys]
     for k in keys:
         v = xarray_dict[k]
         if isinstance(v, dict):


### PR DESCRIPTION
# Pull Request

## Description

This PR speeds up the `tensorstore_compute()` function by being more specific about the order in which things are loaded. Most of our input datasets (like sat and NWP) use `xarray-tensorstore` and therefore we kick them off reading asynchronously. These reads are started first, then we enter into the `compute()` function. Inside the compute function the interpreter is blocked at each dataset until all the reads are done. 

For the `xarray-tensorstore` data sources it doesn't matter what order we try to compute them in, we are basically just waiting for all of them to finish since those reads are happening in parallel. However, the site and GSP data do not use tensorstore - therefore it is better to load the site and GSP values at the start of the compute function rather than towards the end. This allows the `xarray-tensotore` reads to continue in the background whilst we load the site/GSP data and saves time per sample

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
