### PR TITLE
(Speed-up) Eagerly load GSP

### DIFF
--- a/ocf_data_sampler/load/gsp.py
+++ b/ocf_data_sampler/load/gsp.py
@@ -32,7 +32,7 @@ def open_gsp(
     boundaries_version: str = "20220314",
     public: bool = False,
 ) -> xr.DataArray:
-    """Open the GSP data and validates its data types.
+    """Open and eagerly load the GSP data and validates its data types.
 
     Args:
         zarr_path: Path to the GSP zarr data
@@ -93,4 +93,6 @@ def open_gsp(
             dtype = gsp_da.coords[coord].dtype
             raise TypeError(f"{coord} should be {expected_dtype.__name__}, not {dtype}")
 
+    # Below we load the data eagerly into memory - this makes the dataset faster to sample from, but
+    # at the cost of a little extra memory usage
     return gsp_da.compute()

--- a/ocf_data_sampler/load/gsp.py
+++ b/ocf_data_sampler/load/gsp.py
@@ -93,4 +93,4 @@ def open_gsp(
             dtype = gsp_da.coords[coord].dtype
             raise TypeError(f"{coord} should be {expected_dtype.__name__}, not {dtype}")
 
-    return gsp_da
+    return gsp_da.compute()


### PR DESCRIPTION
# Pull Request

## Description

This PR changes the GSP data to be eagerly loaded instead of lazy. We've gone back and forth on this a couple of times, but I think eagerly loading is better. 

I tested this on donatello and got a 5% speed up in the dataloader when using 32 workers at a cost of an extra 8GB ram usage (32GB when lazy 40GB when eager). I think this cost os worth the speed-up. 

Another option could have been to use `xarray-tensorstore` for the GSP data, but at such a low RAM penalty I think eager loading is still better. It also removes uncertainty about what the best method for chunking the dataset is. And it allows the dataset to still be loaded from cloud storage anonymously by the open-data-pvnet community.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
