### PR TITLE
Add dataset pickle caching

### DIFF
--- a/ocf_data_sampler/torch_datasets/datasets/picklecache.py
+++ b/ocf_data_sampler/torch_datasets/datasets/picklecache.py
@@ -1,0 +1,29 @@
+import os
+import pickle
+
+
+class PickleCacheMixin:
+    def __init__(self, *args, **kwargs):
+        self._pickle_path = None
+        super().__init__(*args, **kwargs)  # cooperative multiple inheritance
+
+    def presave_pickle(self, pickle_path: str) -> None:
+        """Save the full object state to a pickle file and store the pickle path."""
+        self._pickle_path = pickle_path
+        with open(pickle_path, "wb") as f:
+            pickle.dump(self.__dict__, f)
+
+    def __getstate__(self):
+        """If presaved, only pickle reference. Otherwise pickle everything."""
+        if self._pickle_path:
+            return {"_pickle_path": self._pickle_path}
+        else:
+            return self.__dict__
+
+    def __setstate__(self, state):
+        """Restore object from pickle, reloading from presaved file if possible."""
+        self.__dict__.update(state)
+        if self._pickle_path and os.path.exists(self._pickle_path):
+            with open(self._pickle_path, "rb") as f:
+                saved_state = pickle.load(f)
+                self.__dict__.update(saved_state)

--- a/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
+++ b/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
@@ -19,6 +19,7 @@ from ocf_data_sampler.numpy_sample.common_types import NumpyBatch, NumpySample
 from ocf_data_sampler.numpy_sample.gsp import GSPSampleKey
 from ocf_data_sampler.numpy_sample.nwp import NWPSampleKey
 from ocf_data_sampler.select import Location, fill_time_periods
+from ocf_data_sampler.torch_datasets.datasets.picklecache import PickleCacheMixin
 from ocf_data_sampler.torch_datasets.utils import (
     add_alterate_coordinate_projections,
     config_normalization_values_to_dicts,
@@ -67,7 +68,7 @@ def get_gsp_locations(
     return locations
 
 
-class AbstractPVNetUKDataset(Dataset):
+class AbstractPVNetUKDataset(PickleCacheMixin, Dataset):
     """Abstract class for PVNet UK datasets."""
 
     def __init__(
@@ -85,6 +86,8 @@ class AbstractPVNetUKDataset(Dataset):
             end_time: Limit the init-times to be before this
             gsp_ids: List of GSP IDs to create samples for. Defaults to all
         """
+        super().__init__()
+
         config = load_yaml_configuration(config_filename)
         datasets_dict = get_dataset_dict(config.input_data, gsp_ids=gsp_ids)
 
@@ -223,7 +226,6 @@ class AbstractPVNetUKDataset(Dataset):
             freq=minutes(config.input_data.gsp.time_resolution_minutes),
         )
         return valid_t0_times
-
 
 
 class PVNetUKRegionalDataset(AbstractPVNetUKDataset):

--- a/ocf_data_sampler/torch_datasets/datasets/site.py
+++ b/ocf_data_sampler/torch_datasets/datasets/site.py
@@ -24,6 +24,7 @@ from ocf_data_sampler.select import (
     find_contiguous_t0_periods,
     intersection_of_multiple_dataframes_of_periods,
 )
+from ocf_data_sampler.torch_datasets.datasets.picklecache import PickleCacheMixin
 from ocf_data_sampler.torch_datasets.utils import (
     add_alterate_coordinate_projections,
     config_normalization_values_to_dicts,
@@ -144,7 +145,7 @@ def process_and_combine_datasets(
     return combined_sample
 
 
-class SitesDataset(Dataset):
+class SitesDataset(PickleCacheMixin, Dataset):
     """A torch Dataset for creating PVNet Site samples."""
 
     def __init__(
@@ -160,6 +161,8 @@ class SitesDataset(Dataset):
             start_time: Limit the init-times to be after this
             end_time: Limit the init-times to be before this
         """
+        super().__init__()
+
         config = load_yaml_configuration(config_filename)
         datasets_dict = get_dataset_dict(config.input_data)
 
@@ -301,7 +304,7 @@ class SitesDataset(Dataset):
         return self._get_sample(t0, location)
 
 
-class SitesDatasetConcurrent(Dataset):
+class SitesDatasetConcurrent(PickleCacheMixin, Dataset):
     """A torch Dataset for creating PVNet Site batches with samples for all sites."""
 
     def __init__(
@@ -317,6 +320,8 @@ class SitesDatasetConcurrent(Dataset):
             start_time: Limit the init-times to be after this
             end_time: Limit the init-times to be before this
         """
+        super().__init__()
+
         config = load_yaml_configuration(config_filename)
         datasets_dict = get_dataset_dict(config.input_data)
 

--- a/tests/torch_datasets/test_pvnet_uk.py
+++ b/tests/torch_datasets/test_pvnet_uk.py
@@ -1,6 +1,7 @@
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
+import pickle
 
 from ocf_data_sampler.config import load_yaml_configuration, save_yaml_configuration
 from ocf_data_sampler.config.model import SolarPosition
@@ -230,3 +231,28 @@ def test_pvnet_uk_regional_dataset_raw_sample_iteration(pvnet_config_filename):
     assert raw_sample["solar_elevation"].shape == (expected_time_steps,)
 
     assert isinstance(raw_sample["gsp_id"], int | np.integer)
+
+
+def test_pvnet_uk_regional_dataset_pickle(tmp_path, pvnet_config_filename):
+
+    pickle_path = f"{tmp_path}.pkl"
+    dataset = PVNetUKRegionalDataset(pvnet_config_filename)
+
+    # Presave the pickled dataset
+    dataset.presave_pickle(pickle_path)
+
+    # Since its been pe-pickled this should just return a reference to the previous pickle
+    pickle_bytes = pickle.dumps(dataset)
+
+    # Check the path is in the pickle object
+    assert pickle_path.encode('utf-8') in pickle_bytes
+
+    # Check we can reload the object
+    _ = pickle.loads(pickle_bytes)
+
+
+    # Check we can still pickle and unpickle if we don't presave
+    dataset = PVNetUKRegionalDataset(pvnet_config_filename)
+    pickle_bytes = pickle.dumps(dataset)
+    _ = pickle.loads(pickle_bytes)
+


### PR DESCRIPTION
# Pull Request

## Description

This PR helps to solve the problem of the dataloaders in PVNet taking a very long time start when using multiple workers.

This ws inspired by a discussion over at: https://github.com/pytorch/pytorch/issues/139792

This adds the ability to cache a pickled version of the dataset. 

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
