### PR TITLE
Convert index to int for site getitem

### DIFF
--- a/ocf_data_sampler/torch_datasets/datasets/site.py
+++ b/ocf_data_sampler/torch_datasets/datasets/site.py
@@ -261,9 +261,9 @@ class SitesDataset(PickleCacheMixin, Dataset):
 
     @override
     def __getitem__(self, idx: int) -> dict:
-        
+
         idx = int(idx)
-        
+
         # Get the coordinates of the sample
         t0, site_id = self.valid_t0_and_site_ids.iloc[idx]
 

--- a/ocf_data_sampler/torch_datasets/datasets/site.py
+++ b/ocf_data_sampler/torch_datasets/datasets/site.py
@@ -261,6 +261,9 @@ class SitesDataset(PickleCacheMixin, Dataset):
 
     @override
     def __getitem__(self, idx: int) -> dict:
+        
+        idx = int(idx)
+        
         # Get the coordinates of the sample
         t0, site_id = self.valid_t0_and_site_ids.iloc[idx]
 


### PR DESCRIPTION
# Pull Request

## Description
This adds casting the index in `_getitem_` as `int` because it is currently supplied as a tensor, which breaks pandas indexing. Judging by [this line](https://github.com/openclimatefix/ocf-data-sampler/blob/21e76fba7f2a64d6224d7a8be6443951d38e5aaa/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py#L272C9-L272C23) we've had the same issue in the GSP pipeline, so just adding this for site.

## How Has This Been Tested?

- [X] Yes

Running training on prem

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
