### PR TITLE
Fixes #330 by ensuring site generation data is cast to float on initialization.

### DIFF
--- a/ocf_data_sampler/torch_datasets/sample/site.py
+++ b/ocf_data_sampler/torch_datasets/sample/site.py
@@ -1,9 +1,11 @@
 """PVNet Site sample implementation for netCDF data handling and conversion."""
 
 import torch
+import numpy as np
 from typing_extensions import override
 
 from ocf_data_sampler.numpy_sample.common_types import NumpySample
+from ocf_data_sampler.numpy_sample import SiteSampleKey
 
 from .base import SampleBase
 
@@ -19,6 +21,7 @@ class SiteSample(SampleBase):
 
     @override
     def to_numpy(self) -> NumpySample:
+        self._data[SiteSampleKey.generation] = self._data[SiteSampleKey.generation].astype(np.float32)
         return self._data
 
     @override

--- a/tests/torch_datasets/sample/test_site_sample.py
+++ b/tests/torch_datasets/sample/test_site_sample.py
@@ -89,7 +89,8 @@ def test_to_numpy(numpy_sample):
     assert isinstance(site_data, np.ndarray)
     assert site_data.ndim == 1
     assert len(site_data) == 7
-    assert np.all(site_data >= 0) and np.all(site_data <= 1)
+    assert site_data.dtype == np.float32
+    assert np.all(site_data >= 0) 
 
     # Check NWP
     assert "ukv" in numpy_data["nwp"]


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes issue #330, where site generation of dtype int was not allowed. This was being caused because of an assert statement which ensured the data values stay between 0 and 1 and are float values.

Fixes #
Made the data convert to float before being initialised in class. Also changed the assert statement to ensure that the values are float and >= 0.


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
