### PR TITLE
Change site loader

### DIFF
--- a/ocf_data_sampler/load/site.py
+++ b/ocf_data_sampler/load/site.py
@@ -31,8 +31,8 @@ def open_site(generation_file_path: str, metadata_file_path: str) -> xr.DataArra
         capacity_kwp=("site_id", metadata_df["capacity_kwp"].values),
     )
 
-    # Sanity checks
-    # Allow NaNs in generation_kw as can have non overlapping time periods for sites
+    # Sanity checks, to prevent inf or negative values
+    # Note NaNs are allowed in generation_kw as can have non overlapping time periods for sites
     if np.isinf(generation_ds.generation_kw.values).all():
         raise ValueError("generation_kw contains infinite (+/- inf) values")
     if not (generation_ds.capacity_kwp.values > 0).all():

--- a/ocf_data_sampler/load/site.py
+++ b/ocf_data_sampler/load/site.py
@@ -57,4 +57,8 @@ def open_site(generation_file_path: str, metadata_file_path: str) -> xr.DataArra
             dtype = site_da.coords[coord].dtype
             allowed = ", ".join(dt.__name__ for dt in expected_dtypes)
             raise TypeError(f"{coord} should be one of ({allowed}), not {dtype}")
+
+    # Load the data eagerly into memory by calling compute
+    # this makes the dataset faster to sample from, but
+    # at the cost of a little extra memory usage
     return site_da.compute()

--- a/tests/load/test_load_sites.py
+++ b/tests/load/test_load_sites.py
@@ -48,5 +48,5 @@ def test_open_site_bad_dtype(tmp_path: Path):
     )
     metadata.to_csv(meta_path)
 
-    with pytest.raises(TypeError, match="site_id should be integer"):
+    with pytest.raises(TypeError, match="site_id should be one of (integer), not float64"):
         open_site(generation_file_path=gen_path, metadata_file_path=meta_path)

--- a/tests/load/test_load_sites.py
+++ b/tests/load/test_load_sites.py
@@ -48,5 +48,5 @@ def test_open_site_bad_dtype(tmp_path: Path):
     )
     metadata.to_csv(meta_path)
 
-    with pytest.raises(TypeError, match="site_id should be one of (integer), not float64"):
+    with pytest.raises(TypeError, match="site_id should be one of.*integer.*"):
         open_site(generation_file_path=gen_path, metadata_file_path=meta_path)


### PR DESCRIPTION
# Pull Request

## Description

Three changes are including in this PR:

- The main change is the relaxation of one of the checks to allow `NaN` values in the site generation data, this is due to the fact if you create a xarray dataset of generation data from different sites which have some non-overlapping time periods of data availability the resulting generation data variable will have `NaN` values which is fine as this is handled in our sampling logic [here](https://github.com/openclimatefix/ocf-data-sampler/blob/main/ocf_data_sampler/torch_datasets/datasets/site.py#L228-L231) which handles in each site separately and then combines all available samples
- The next biggest change is following suit from a change in the gsp loader to load the site generation data into memory rather than have this still be lazy loaded, this speeds up data sampling and comes at a small extra memory cost as the site data is generally small. 
- Lastly there is a small change to allow either int or float for capacity values for site metadata as either would work 

## How has this been tested?
- Created a site generation dataset with non overlapping time periods (so with `NaN` values in the data variable) between sites and created samples with these changes and updated unit tests for other change. 


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
