### PR TITLE
Remove cast index to int

### DIFF
--- a/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
+++ b/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
@@ -267,10 +267,8 @@ class PVNetUKRegionalDataset(AbstractPVNetUKDataset):
 
     @override
     def __getitem__(self, idx: int) -> NumpySample:
+        
         # Get the coordinates of the sample
-
-        idx = int(idx)
-
         if idx >= len(self):
             raise ValueError(f"Index {idx} out of range for dataset of length {len(self)}")
 

--- a/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
+++ b/ocf_data_sampler/torch_datasets/datasets/pvnet_uk.py
@@ -267,7 +267,7 @@ class PVNetUKRegionalDataset(AbstractPVNetUKDataset):
 
     @override
     def __getitem__(self, idx: int) -> NumpySample:
-        
+
         # Get the coordinates of the sample
         if idx >= len(self):
             raise ValueError(f"Index {idx} out of range for dataset of length {len(self)}")

--- a/ocf_data_sampler/torch_datasets/datasets/site.py
+++ b/ocf_data_sampler/torch_datasets/datasets/site.py
@@ -262,8 +262,6 @@ class SitesDataset(PickleCacheMixin, Dataset):
     @override
     def __getitem__(self, idx: int) -> dict:
 
-        idx = int(idx)
-
         # Get the coordinates of the sample
         t0, site_id = self.valid_t0_and_site_ids.iloc[idx]
 


### PR DESCRIPTION
# Pull Request

## Description

openclimatefix/pvnet#458 allows us to remove the integer casting here

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
