### PR TITLE
remove dtype check for channels from nwp.py

### DIFF
--- a/ocf_data_sampler/load/nwp/nwp.py
+++ b/ocf_data_sampler/load/nwp/nwp.py
@@ -29,7 +29,6 @@ def _validate_nwp_data(data_array: xr.DataArray, provider: str) -> None:
     common_expected_dtypes = {
         "init_time_utc": np.datetime64,
         "step": np.timedelta64,
-        "channel": (np.str_, np.object_),
     }
 
     geographic_spatial_dtypes = {


### PR DESCRIPTION
# Pull Request

## Description

We fail the dtype check for channels on the NWP load frequently due to channels being stored as `dtype('O')` in a lot of our archives. Checking for dtype object is unlikely to catch anything as it allows pretty much any content, including a mix of dtypes, so removing this check altogether.

Fixes #329


## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [X] Yes

Ran training without the check.

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
