### PR TITLE
chore(workflows): Make pull test strategy match branch

### DIFF
--- a/.github/workflows/pull_ci.yml
+++ b/.github/workflows/pull_ci.yml
@@ -16,3 +16,4 @@ jobs:
       containerfile: 'None'
       tests_folder: 'tests'
       tests_matrix: true
+      test_python_versions: '["3.11", "3.12"]'


### PR DESCRIPTION
The test matrix for the branch strategy is mismatched to that of the pull request strategy. 

[External PRs are being tested against 3.10](https://github.com/openclimatefix/ocf-data-sampler/blob/cf39173ed798c2195a239195598ecb4f141d1208/.github/workflows/pull_ci.yml#L10-L18) (and [failing](https://github.com/openclimatefix/ocf-data-sampler/actions/runs/17862592414/job/50916573923?pr=292)), while [branches are being tested against 3.11 up only](https://github.com/openclimatefix/ocf-data-sampler/blob/cf39173ed798c2195a239195598ecb4f141d1208/.github/workflows/branch_ci.yml#L19). This PR brings the Pull workflow up to speed with the branch workflow.

(Also, the 3.10 test matrix entry can never pass due to the [python requirement in the pyproject](https://github.com/openclimatefix/ocf-data-sampler/blob/cf39173ed798c2195a239195598ecb4f141d1208/pyproject.toml#L12). If we're moving away from 3.10 support on all our repos, it might be worth removing it from the default matrix: see [workflows PR](https://github.com/openclimatefix/.github/pull/89))