### PR TITLE
Conftest streamlining

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -390,10 +390,10 @@ def create_site_data(
             "generation_kw": da_gen,
         },
     )
-    
+
     data_path = tmp_path_base / f"sites_data_{param_key}.netcdf"
     metadata_path = tmp_path_base / f"sites_metadata_{param_key}.csv"
-    
+
     generation_ds.to_netcdf(data_path)
     meta_df.to_csv(metadata_path, index=False)
 


### PR DESCRIPTION
Relating to https://github.com/openclimatefix/ocf-data-sampler/issues/358

For tests/conftest.py only - few updates to just streamline:

- Use Path and constants - cleaner, consistent paths as opposed to os.path.
- Session RNG and related helpers - reproducible random data and less duplication in dataset creation pretty much.
- Consistent zarr writes and chunking - should be faster test runs, little simpler and no deprecated dtypes (must note, left this out as overall test time increased slightly?).