### PR TITLE
Support UKV variable name change #364: Conditionally rename x,y dims …

### DIFF
--- a/ocf_data_sampler/load/nwp/providers/ukv.py
+++ b/ocf_data_sampler/load/nwp/providers/ukv.py
@@ -21,14 +21,19 @@ def open_ukv(zarr_path: str | list[str]) -> xr.DataArray:
     """
     ds = open_zarr_paths(zarr_path, backend="tensorstore")
 
-    ds = ds.rename(
-        {
-            "init_time": "init_time_utc",
-            "variable": "channel",
-            "x": "x_osgb",
-            "y": "y_osgb",
-        },
-    )
+    # Build rename dictionary conditionally based on existing dimensions
+    rename_dict = {
+        "init_time": "init_time_utc",
+        "variable": "channel",
+    }
+    
+    # Only rename x,y to x_osgb,y_osgb if the legacy names exist
+    if "x" in ds.dims:
+        rename_dict["x"] = "x_osgb"
+    if "y" in ds.dims:
+        rename_dict["y"] = "y_osgb"
+
+    ds = ds.rename(rename_dict)
 
     check_time_unique_increasing(ds.init_time_utc)
 


### PR DESCRIPTION
# Pull Request

## Description

This PR adds backward compatibility support for UKV variable name changes (#364). 

**Problem**: New UKV data uses different dimension names (`x_osgb`, `y_osgb`) while legacy data uses (`x`, `y`). The current code always renames `x`→`x_osgb` and `y`→`y_osgb`, which breaks with the new dataset.

**Solution**: Modified the `open_ukv` function to conditionally rename spatial coordinates only when legacy dimension names (`x`, `y`) are present. This maintains compatibility with both:
- Legacy data (renames `x`→`x_osgb`, `y`→`y_osgb`)
- New data (no renaming needed since dimensions are already `x_osgb`, `y_osgb`)

## How Has This Been Tested?

- [x] Tested with both legacy and new UKV dataset formats
- [x] Verified spatial coordinates are properly handled in both cases
- [x] Confirmed the function doesn't break existing workflows

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes - verified data structure and coordinate naming in both scenarios

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings