### PR TITLE
Tensorstore hotfix with python version restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 name = "ocf-data-sampler"
 dynamic = ["version"] # Set automtically using git: https://setuptools-git-versioning.readthedocs.io/en/stable/
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 license = { file = "LICENSE" }
 authors = [
     { name = "Open Climate Fix team", email = "info@openclimatefix.org" },
@@ -36,7 +36,6 @@ dependencies = [
     "pyresample",
     "h5netcdf",
     "xarray-tensorstore==0.1.5",
-    "tensorstore==0.1.77",
     "zarr>=3",
 ]
 


### PR DESCRIPTION
# Pull Request

## Description

`tensorstore` which we rely on due it being used in `xarray-tensorstore` which is a dependency in this library doesn't seem to fully support python 3.14 yet or at least we run into issues when trying to install it in our CI with python 3.14, e.g. [here](https://github.com/openclimatefix/ocf-data-sampler/actions/runs/19066285088/job/54457640936), as a short term fix to get around this this PR changes the python version supported by `ocf-data-sampler` to `<3.14` 
