### PR TITLE
Make compatible with nowcasting_datamodel

### DIFF
--- a/ocf_data_sampler/torch_datasets/pvnet_dataset.py
+++ b/ocf_data_sampler/torch_datasets/pvnet_dataset.py
@@ -3,11 +3,9 @@
 import logging
 import os
 import pickle
-import warnings
 
 import pandas as pd
 import xarray as xr
-from pydantic.warnings import UnsupportedFieldAttributeWarning
 from torch.utils.data import Dataset
 from typing_extensions import override
 
@@ -42,8 +40,6 @@ from ocf_data_sampler.torch_datasets.utils import (
 )
 from ocf_data_sampler.utils import minutes, tensorstore_compute
 
-# Ignore pydantic warning which doesn't cause an issue
-warnings.filterwarnings("ignore", category=UnsupportedFieldAttributeWarning)
 
 xr.set_options(keep_attrs=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "dask",
     "matplotlib",
     "pvlib",
-    "pydantic",
+    "pydantic==2.5.3", # This can be unpinned once nowcasting_datamodel is removed from uk-pvnet-app
     "pyproj",
     "pyaml_env",
     "pyresample",


### PR DESCRIPTION
For now we need the nowcasting_datamodel in the uk-pvnert-app. nowcasting_datamodel has a pin on the versions of pydantic. This matches to that pinned version