### PR TITLE
Add minimum version pin to pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "dask",
     "matplotlib",
     "pvlib",
-    "pydantic",
+    "pydantic>=2.11.8",
     "pyproj",
     "pyaml_env",
     "pyresample",


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a minimum version pin for pydantic due to the use of this [pydantic warning function](https://github.com/openclimatefix/ocf-data-sampler/blob/main/ocf_data_sampler/torch_datasets/pvnet_dataset.py#L10) which was introduced from version 2.11.8 onwards  
