### PR TITLE
fixed type hints for coord_system parameter in the location class

### DIFF
--- a/ocf_data_sampler/select/location.py
+++ b/ocf_data_sampler/select/location.py
@@ -7,7 +7,7 @@ allowed_coord_systems = {"osgb", "lon_lat", "geostationary"}
 class Location:
     """A spatial location."""
 
-    def __init__(self, x: float, y: float, coord_system: int, id: int | str | None = None) -> None:
+    def __init__(self, x: float, y: float, coord_system: str, id: int | str | None = None) -> None:
         """A spatial location.
 
         Args:
@@ -42,7 +42,7 @@ class Location:
                 f"{list(self._projections.keys())}",
             )
 
-    def add_coord_system(self, x: float, y: float, coord_system: int) -> None:
+    def add_coord_system(self, x: float, y: float, coord_system: str) -> None:
         """Add the equivalent location in a different coordinate system.
 
         Args:


### PR DESCRIPTION
# Pull Request

## Description
`coord_system` in `Location.__init__` and `Location.add_coord_system` was typed as `int`, but the codebase uses string. also,

while checking the tests for the repository i found the tests/select/test_location.py file uses coord_system='osgb' which is a string, whereas in the select/location.py the coord_system is typed as int in two functions, i think might cause issues. 

## How Has This Been Tested?
ran pytest again through the repo again, all the checks passed without any breaking