### PR TITLE
bug(dependencies): Hot-fix tests for pandas 3.0.0

### DIFF
--- a/tests/select/test_find_contiguous_time_periods.py
+++ b/tests/select/test_find_contiguous_time_periods.py
@@ -33,10 +33,10 @@ def test_find_contiguous_t0_periods():
     interval_end = pd.Timedelta(15, "min")
 
     datetimes = pd.date_range(
-        "2023-01-01 12:00", 
-        "2023-01-01 17:00", 
-        freq=freq, 
-        unit="ns"
+        "2023-01-01 12:00",
+        "2023-01-01 17:00",
+        freq=freq,
+        unit="ns",
     ).delete([5, 6, 30])
 
     periods = find_contiguous_t0_periods(
@@ -82,10 +82,10 @@ def test_find_contiguous_t0_periods_nwp():
     # Create 3-hourly init times with a few time stamps missing
     freq = pd.Timedelta(3, "h")
     init_times = pd.date_range(
-        "2023-01-01 03:00", 
-        "2023-01-02 21:00", 
-        freq=freq, 
-        unit="ns"
+        "2023-01-01 03:00",
+        "2023-01-02 21:00",
+        freq=freq,
+        unit="ns",
     ).delete([1, 4, 5, 6, 7, 9, 10])
 
     # Choose some history durations and max stalenesses


### PR DESCRIPTION
# Pull Request

## Description

This PR modifies the tests to be compatible with pandas v3.0. 

Pandas v3 made some changes to the [datetime data-type inferred from string format](https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#datetime-timedelta-resolution-inference). This is breaking our tests as previously all results and expected results were `datetime[ns]` but since pandas v3 had become a mixture of `datetime[ns]` and `datetime[us]`. This is a hot-fix for the tests, but I haven't gone through to make sure there isn't anything  more insidious caused by the upgrade to pandas v3

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
