### PR TITLE
Improving `open_nwp` function and dev-dependency change in `pyproject.toml`

### DIFF
--- a/ocf_data_sampler/load/nwp/nwp.py
+++ b/ocf_data_sampler/load/nwp/nwp.py
@@ -12,7 +12,7 @@ from ocf_data_sampler.load.nwp.providers.gfs import open_gfs
 from ocf_data_sampler.load.nwp.providers.icon import open_icon_eu
 from ocf_data_sampler.load.nwp.providers.ukv import open_ukv
 
-_OPENERS: dict[str, Callable[..., xr.DataArray]] = {
+_OPEN_NWP_FUNCTIONS: dict[str, Callable[..., xr.DataArray]] = {
     "ukv": open_ukv,
     "ecmwf": open_ifs,
     "mo_global": open_ifs,
@@ -104,10 +104,11 @@ def open_nwp(
     """
     provider = provider.lower()
 
-    opener = _OPENERS.get(provider)
-    if opener is None:
-        supported = ", ".join(sorted(_OPENERS.keys()))
+    if provider not in _OPEN_NWP_FUNCTIONS:
+        supported = ", ".join(sorted(_OPEN_NWP_FUNCTIONS.keys()))
         raise ValueError(f"Unknown provider: {provider!r}. Supported: {supported}")
+
+    opener = _OPEN_NWP_FUNCTIONS[provider]
 
     kwargs = {"zarr_path": zarr_path}
     if provider == "gfs" and public:


### PR DESCRIPTION
# Pull Request

## Description
While going through the code base I found in `nwp.py` the function `open_nwp` has an `if-else` block which requires changing everytime new provider is added, I modifed logic outside of the function to update in a private dictionaries, instead of adding `if-else`.

~While installing `dev` dependency, I observed that these were grouped under `[dependency-groups]` , I changed it to `[project.optional-dependencies]` to make the `uv pip install -e .[dev]` work. (If this was intentional, I can revert the changes.)~ (Reverted due to CI breaking)

Fixes #

## How Has This Been Tested?
All tests passes, except one unrelated test being skipped `test_load_gfs`

I haven't run `black` or `ruff` since on running `black` , it is reformatting more than 50 files, there is no defined `pre-commit`

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
