### PR TITLE
Make time filtering in PVNet datasets more flexible

### DIFF
--- a/ocf_data_sampler/torch_datasets/pvnet_dataset.py
+++ b/ocf_data_sampler/torch_datasets/pvnet_dataset.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import warnings
 
+import numpy as np
 import pandas as pd
 import xarray as xr
 from pydantic.warnings import UnsupportedFieldAttributeWarning
@@ -100,14 +101,38 @@ def get_locations(generation_data: xr.DataArray) -> list[Location]:
     return locations
 
 
+def get_time_periods_mask(
+    times: pd.DatetimeIndex,
+    time_periods: list[tuple[str | None, str | None]],
+) -> np.ndarray:
+    """Get a boolean mask showing which times fall within any of the specified time periods.
+
+    Args:
+        times: DatetimeIndex of times to filter
+        time_periods: List of tuples specifying the start and end times for each period
+    """
+    if len(time_periods)==0:
+        raise ValueError("At least one time period must be provided")
+
+    mask = np.full(len(times), False)
+
+    for start_time, end_time in time_periods:
+
+        start_time = times[0] if start_time is None else pd.Timestamp(start_time)
+        end_time = times[-1] if end_time is None else pd.Timestamp(end_time)
+
+        mask |= (times >= start_time) & (times <= end_time)
+
+    return mask
+
+
 class AbstractPVNetDataset(PickleCacheMixin, Dataset):
     """Abstract class for PVNet datasets."""
 
     def __init__(
         self,
         config_filename: str,
-        start_time: str | None = None,
-        end_time: str | None = None,
+        time_periods: list[tuple[str | None, str | None]] | None = None,
     ) -> None:
         """A generic torch Dataset for creating PVNet samples.
 
@@ -117,8 +142,7 @@ class AbstractPVNetDataset(PickleCacheMixin, Dataset):
 
         Args:
             config_filename: Path to the configuration file
-            start_time: Limit the init-times to be after this
-            end_time: Limit the init-times to be before this
+            time_periods: List of tuples specifying the start and end times for each period
         """
         super().__init__()
 
@@ -133,11 +157,9 @@ class AbstractPVNetDataset(PickleCacheMixin, Dataset):
             valid_t0_times = self.find_valid_t0_times(datasets_dict, config)
 
             # Filter t0 times to given range
-            if start_time is not None:
-                valid_t0_times = valid_t0_times[valid_t0_times >= pd.Timestamp(start_time)]
-
-            if end_time is not None:
-                valid_t0_times = valid_t0_times[valid_t0_times <= pd.Timestamp(end_time)]
+            if time_periods is not None:
+                mask = get_time_periods_mask(valid_t0_times, time_periods)
+                valid_t0_times = valid_t0_times[mask]
 
             self.valid_t0_times = valid_t0_times
         else:
@@ -148,15 +170,10 @@ class AbstractPVNetDataset(PickleCacheMixin, Dataset):
             valid_t0_and_location_ids = self.find_valid_t0_and_location_ids(datasets_dict, config)
 
             # Filter t0 times to given range
-            if start_time is not None:
-                valid_t0_and_location_ids = valid_t0_and_location_ids[
-                    valid_t0_and_location_ids["t0"] >= pd.Timestamp(start_time)
-                ]
+            if time_periods is not None:
+                mask = get_time_periods_mask(valid_t0_and_location_ids["t0"], time_periods)
+                valid_t0_and_location_ids = valid_t0_and_location_ids[mask]
 
-            if end_time is not None:
-                valid_t0_and_location_ids = valid_t0_and_location_ids[
-                    valid_t0_and_location_ids["t0"] <= pd.Timestamp(end_time)
-                ]
             self.valid_t0_and_location_ids = valid_t0_and_location_ids
 
         # Construct list of locations to sample from
@@ -345,10 +362,9 @@ class PVNetDataset(AbstractPVNetDataset):
     def __init__(
         self,
         config_filename: str,
-        start_time: str | None = None,
-        end_time: str | None = None,
+        time_periods: list[tuple[None | str, None | str]] | None = None,
     ) -> None:
-        super().__init__(config_filename, start_time, end_time)
+        super().__init__(config_filename, time_periods)
 
         # Construct a lookup for locations - useful for users to construct sample by location ID
         self.location_lookup = {loc.id: loc for loc in self.locations}
@@ -438,11 +454,10 @@ class PVNetConcurrentDataset(AbstractPVNetDataset):
     def __init__(
         self,
         config_filename: str,
-        start_time: str | None = None,
-        end_time: str | None = None,
+        time_periods: list[tuple[str | None, str | None]] | None = None,
     ) -> None:
 
-        super().__init__(config_filename, start_time, end_time)
+        super().__init__(config_filename, time_periods)
 
         self.datasets_dict = reduce_spatial_extent_of_datasets(
             self.datasets_dict,

--- a/tests/torch_datasets/test_pvnet_dataset.py
+++ b/tests/torch_datasets/test_pvnet_dataset.py
@@ -1,6 +1,7 @@
 import pickle
 
 import numpy as np
+import pandas as pd
 import torch
 from torch.utils.data import DataLoader
 
@@ -10,6 +11,7 @@ from ocf_data_sampler.numpy_sample.collate import stack_np_samples_into_batch
 from ocf_data_sampler.torch_datasets.pvnet_dataset import (
     PVNetConcurrentDataset,
     PVNetDataset,
+    get_time_periods_mask,
 )
 from ocf_data_sampler.torch_datasets.utils.torch_batch_utils import (
     batch_to_tensor,
@@ -17,13 +19,51 @@ from ocf_data_sampler.torch_datasets.utils.torch_batch_utils import (
 )
 
 
-def test_pvnet_dataset(pvnet_config_filename):
-    dataset = PVNetDataset(pvnet_config_filename)
+def test_get_time_periods_mask():
+    times = pd.to_datetime([
+        "2023-01-01 05:00",
+        "2023-01-01 06:00",
+        "2023-01-01 06:30",
+        "2023-01-01 07:00",
+        "2023-01-01 11:00",
+        "2023-01-01 12:00",
+        "2023-01-01 12:30",
+        "2023-01-01 13:00",
+    ])
 
-    assert len(dataset.locations) == 317  # Quantity of regional GSPs
-    # NB. I have not checked the value (39 below) is in fact correct
-    assert len(dataset.valid_t0_times) == 39
-    assert len(dataset) == 317 * 39
+    mask = get_time_periods_mask(
+        times,
+        time_periods=[
+            ("2023-01-01 06:00", "2023-01-01 07:00"),
+            ("2023-01-01 12:00", "2023-01-01 13:00"),
+        ],
+    )
+    expected_mask = np.array([False, True, True, True, False, True, True, True])
+    assert np.array_equal(mask, expected_mask), f"Expected {expected_mask} but got {mask}"
+
+    mask = get_time_periods_mask(
+        times,
+        time_periods=[(None, "2023-01-01 07:00")],
+    )
+    expected_mask = np.array([True, True, True, True, False, False, False, True])
+    assert np.array_equal(mask, expected_mask), f"Expected {expected_mask} but got {mask}"
+
+
+def test_pvnet_dataset(pvnet_config_filename):
+    dataset = PVNetDataset(
+        pvnet_config_filename,
+        time_periods=[
+            ("2023-01-01 06:00", "2023-01-01 07:00"),
+            ("2023-01-01 12:00", "2023-01-01 13:00"),
+        ],
+    )
+
+    expected_t0s = 6  # 2 time periods each with 3 t0s (inclusive) at 30 minute intervals
+    num_locs = 317 # Quantity of regional GSPs
+    assert len(dataset.locations) == num_locs
+
+    assert len(dataset.valid_t0_times) == expected_t0s
+    assert len(dataset) == num_locs * expected_t0s
 
     sample = dataset[0]
     assert isinstance(sample, dict)
@@ -71,11 +111,20 @@ def test_pvnet_dataset(pvnet_config_filename):
 
 
 def test_pvnet_dataset_sites(pvnet_site_config_filename):
-    dataset = PVNetDataset(pvnet_site_config_filename)
+    dataset = PVNetDataset(
+        pvnet_site_config_filename,
+        time_periods=[
+            ("2023-01-01 06:00", "2023-01-01 07:00"),
+            ("2023-01-01 12:00", "2023-01-01 13:00"),
+        ],
+    )
 
-    assert len(dataset.locations) == 10
-    # max possible t0s is 10 * 39 if full, so should be less than that
-    assert len(dataset.valid_t0_and_location_ids) < 10 * 39
+    expected_t0s = 6  # 2 time periods each with 3 t0s (inclusive) at 30 minute intervals
+    num_locs = 10
+    assert len(dataset.locations) == num_locs
+    # Should be less than num_locs * expected_t0s as not all locations have data for all t0s
+    # in the time periods
+    assert len(dataset.valid_t0_and_location_ids) < num_locs * expected_t0s
 
     sample = dataset[0]
     assert isinstance(sample, dict)

--- a/tests/torch_datasets/test_pvnet_dataset.py
+++ b/tests/torch_datasets/test_pvnet_dataset.py
@@ -45,7 +45,7 @@ def test_get_time_periods_mask():
         times,
         time_periods=[(None, "2023-01-01 07:00")],
     )
-    expected_mask = np.array([True, True, True, True, False, False, False, True])
+    expected_mask = np.array([True, True, True, True, False, False, False, False])
     assert np.array_equal(mask, expected_mask), f"Expected {expected_mask} but got {mask}"
 
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request enhances the PVNet dataset classes by allowing users to filter data using multiple time periods rather than just a single start and end time. It introduces a new utility function `get_time_periods_mask()` for time period masking and updates both the dataset logic and associated tests to support and validate this more flexible approach.

This makes it easier to perform cross-validation with the dataset. However, note that this is a breaking change and will require corresponding changes in PVNet

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
