### PR TITLE
Metadata warning supress

### DIFF
--- a/ocf_data_sampler/load/open_xarray_tensorstore.py
+++ b/ocf_data_sampler/load/open_xarray_tensorstore.py
@@ -106,7 +106,7 @@ def open_zarr(
         context = ts.Context()
 
     # Avoid using dask by settung `chunks=None`
-    ds = xr.open_zarr(path, chunks=None, mask_and_scale=mask_and_scale)
+    ds = xr.open_zarr(path, chunks=None, mask_and_scale=mask_and_scale, consolidated=False)
 
     if mask_and_scale:
         _raise_if_mask_and_scale_used_for_data_vars(ds)
@@ -146,7 +146,7 @@ def open_zarrs(
     if context is None:
         context = ts.Context()
 
-    ds_list = [xr.open_zarr(p, mask_and_scale=mask_and_scale, decode_timedelta=True) for p in paths]
+    ds_list = [xr.open_zarr(p, mask_and_scale=mask_and_scale, decode_timedelta=True, consolidated=False) for p in paths]
     try:
         ds = xr.concat(
             ds_list,

--- a/ocf_data_sampler/load/open_xarray_tensorstore.py
+++ b/ocf_data_sampler/load/open_xarray_tensorstore.py
@@ -146,7 +146,10 @@ def open_zarrs(
     if context is None:
         context = ts.Context()
 
-    ds_list = [xr.open_zarr(p, mask_and_scale=mask_and_scale, decode_timedelta=True, consolidated=False) for p in paths]
+    ds_list = [xr.open_zarr(p,
+                            mask_and_scale=mask_and_scale,
+                            decode_timedelta=True,
+                            consolidated=False) for p in paths]
     try:
         ds = xr.concat(
             ds_list,


### PR DESCRIPTION
Relating to new sat archive, zarr v3 stores don't have v2 consolidated metadata- RuntimeWarning on every call. This is pretty noisy when loading multiple sat zarrs. No change in behaviour, just removes warning and avoids unnecessary fallback.