### PR TITLE
Add fgn as an NWP provider

### DIFF
--- a/ocf_data_sampler/config/model.py
+++ b/ocf_data_sampler/config/model.py
@@ -18,6 +18,7 @@ NWP_PROVIDERS = [
     "icon_eu",
     "cloudcasting",
     "gencast",
+    "fgn",
 ]
 
 

--- a/ocf_data_sampler/load/nwp/nwp.py
+++ b/ocf_data_sampler/load/nwp/nwp.py
@@ -18,6 +18,7 @@ _OPEN_NWP_FUNCTIONS: dict[str, Callable[..., xr.DataArray]] = {
     "mo_global": open_ifs,
     "icon-eu": open_icon_eu,
     "gencast": open_gdm,
+    "fgn": open_gdm,
     "gfs": open_gfs,
     "cloudcasting": open_cloudcasting,
 }


### PR DESCRIPTION
# Pull Request

## Description

Adding an extra NWP provider (fgn), required to deploy live models that use weathernext2 (fgn) 

