### PR TITLE
Add protocol and fix dropout for LightDataArray

### DIFF
--- a/.github/workflows/branch_ci.yml
+++ b/.github/workflows/branch_ci.yml
@@ -12,7 +12,7 @@ jobs:
     secrets: inherit
     with:
       enable_linting: true
-      enable_typechecking: false
+      enable_typechecking: true
       containerfile: 'None'
       tests_folder: 'tests'
       tests_matrix: true

--- a/.github/workflows/pull_ci.yml
+++ b/.github/workflows/pull_ci.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.fork }}
     with:
       enable_linting: true
-      enable_typechecking: false
+      enable_typechecking: true
       containerfile: 'None'
       tests_folder: 'tests'
       tests_matrix: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     # LSP Support
     "python-lsp-server",
     "python-lsp-ruff",
+    "mypy>=2.3.0",
 ]
 
 [project.urls]
@@ -56,7 +57,7 @@ license-files = []
 where = ["src"]
 
 [tool.setuptools.package-data]
-"*" = ["*.csv"]
+ocf_data_sampler = ["py.typed"]
 
 [tool.setuptools-git-versioning]
 enabled = true
@@ -67,24 +68,30 @@ enabled = true
 # MyPy configuration
 # * See https://mypy.readthedocs.io/en/stable/index.html
 [tool.mypy]
+files = ["src"]
 python_version = "3.12"
 strict = true
 warn_unreachable = true
-warn_return_any = true
-disallow_untyped_defs = true
-plugins = [
-    "numpy.typing.mypy_plugin",
-]
 
 [[tool.mypy.overrides]]
-# Ignore missing imports for libraries that don't have them.
-# If they are ever made, remove from here!
-module = [
-    "fsspec",
-    "s3fs",
-    "zarr",
-]
+module = ["tensorstore.*", "xarray_tensorstore.*", "pyresample.*"]
 ignore_missing_imports = true
+
+# Ratchet: modules not yet conformant. Delete entries as they're fixed.
+[[tool.mypy.overrides]]
+module = [
+    "ocf_data_sampler.datasets.*",
+    "ocf_data_sampler.load.*",
+    "ocf_data_sampler.config.*",
+    "ocf_data_sampler.select.*",
+    "ocf_data_sampler.features.*",
+]
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "ocf_data_sampler.spatial"
+disallow_untyped_calls = false   # pyresample's load_area_from_string is untyped
+
 
 # Ruff configuration
 # * See https://beta.ruff.rs/docs/
@@ -111,14 +118,14 @@ select = [
     "ARG", # flake8 unused arguments
     "DTZ", # flake8 datetimes
     "Q",   # flake8 quotes
-    "TCH", # flake8 typecheck
+    "TC", # flake8 typecheck
     "D",   # pydocstyle
     "RUF", # ruff-specific rules
 ]
 fixable = ["ALL"]
 ignore = [
     "D203", "D213", "D215", "D400", "D401", "D404", "D406",
-    "D407", "D408", "D409", "D413",
+    "D407", "D408", "D409", "D413", "COM812",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ enabled = true
 # * See https://mypy.readthedocs.io/en/stable/index.html
 [tool.mypy]
 files = ["src"]
+exclude = ["^tests/", "^scripts/"]
 python_version = "3.12"
 strict = true
 warn_unreachable = true

--- a/src/ocf_data_sampler/common/lightarray.py
+++ b/src/ocf_data_sampler/common/lightarray.py
@@ -1,5 +1,6 @@
 """A lightweight DataArray-like class."""
 
+from typing import Any, TypedDict
 
 import numpy as np
 import xarray as xr
@@ -7,11 +8,23 @@ from tensorstore import Future as TensorStoreFuture
 from tensorstore import TensorStore
 from xarray_tensorstore import _TensorStoreAdapter
 
+from ocf_data_sampler.common.types import Indexer
+
+
+class LightDataArrayState(TypedDict):
+    """Serialized state of a LightDataArray."""
+
+    _data: np.ndarray | TensorStore
+    dims: tuple[str, ...]
+    coords: dict[str, np.ndarray]
+    attrs: dict[Any, Any]
+    coord_dims: dict[str, tuple[str, ...]]
+
 
 class LightDataArray:
     """A lightweight DataArray-like class."""
 
-    __slots__ = ["attrs", "coord_dims", "coords", "_data", "dims", "future"]
+    __slots__ = ["_data", "attrs", "coord_dims", "coords", "dims", "future"]
 
     def __init__(
         self,
@@ -19,7 +32,7 @@ class LightDataArray:
         dims: tuple[str, ...],
         coords: dict[str, np.ndarray],
         coord_dims: dict[str, tuple[str, ...]],
-        attrs: None | dict = None,
+        attrs: dict[Any, Any] | None = None,
     ) -> None:
         """A lightweight DataArray-like class."""
         self._data = data
@@ -63,17 +76,20 @@ class LightDataArray:
 
         for k, v in da.coords.items():
             if v.ndim <= 1:
-                coord_values[k] = v.values
-                coord_dims[k] = v.dims
+                coord_name = str(k)
+                coord_values[coord_name] = v.values
+                coord_dims[coord_name] = tuple(str(dim) for dim in v.dims)
             else:
                 raise ValueError(
                     "Coordinates with more than 1 dimension not supported. "
                     f"Found coord '{k}' with shape {v.shape}.",
                 )
 
+        dims = tuple(str(d) for d in da.dims)
+
         return cls(
             data=data,
-            dims=da.dims,
+            dims=dims,
             coords=coord_values,
             coord_dims=coord_dims,
             attrs=da.attrs,
@@ -84,7 +100,7 @@ class LightDataArray:
 
         Note this loads the data eagerly.
         """
-        coords_dict = {}
+        coords_dict: dict[str, Any] = {}
         for c, v in self.coords.items():
             cdims = self.coord_dims.get(c, ())
 
@@ -104,8 +120,8 @@ class LightDataArray:
 
     def isel(
         self,
-        indexers: None | dict[str, int | slice | list] = None,
-        **indexers_kwargs: object,
+        indexers: dict[str, Indexer] | None = None,
+        **indexers_kwargs: Indexer,
     ) -> "LightDataArray":
         """Select data by integer index along specified dimensions.
 
@@ -117,9 +133,9 @@ class LightDataArray:
         if indexers is not None:
             indexers_kwargs.update(indexers)
 
-        axis_indexers = [slice(None)] * len(self.dims)
+        axis_indexers: list[Indexer] = [slice(None)] * len(self.dims)
         new_coords = self.coords.copy()
-        dims_to_remove = []
+        dims_to_remove: list[str] = []
 
         for dim, indexer in indexers_kwargs.items():
             if dim not in self.dims:
@@ -194,7 +210,7 @@ class LightDataArray:
             )
         raise KeyError(f"Coordinate '{key}' not found.")
 
-    def __getstate__(self) -> dict:
+    def __getstate__(self) -> LightDataArrayState:
         """Prepare state for pickling, excluding un-picklable attributes."""
         return {
             "_data": self._data,
@@ -204,7 +220,7 @@ class LightDataArray:
             "coord_dims": self.coord_dims,
         }
 
-    def __setstate__(self, state: dict) -> None:
+    def __setstate__(self, state: LightDataArrayState) -> None:
         """Restore state after unpickling."""
         self._data = state["_data"]
         self.dims = state["dims"]

--- a/src/ocf_data_sampler/common/lightarray.py
+++ b/src/ocf_data_sampler/common/lightarray.py
@@ -40,7 +40,7 @@ class LightDataArray:
         self.coords = coords
         self.coord_dims = coord_dims
         self.attrs = attrs or {}
-        self.future: None | TensorStoreFuture = None
+        self.future: TensorStoreFuture[Any] | None = None
 
     @property
     def data(self) -> np.ndarray | TensorStore:

--- a/src/ocf_data_sampler/common/lightarray.py
+++ b/src/ocf_data_sampler/common/lightarray.py
@@ -11,7 +11,7 @@ from xarray_tensorstore import _TensorStoreAdapter
 class LightDataArray:
     """A lightweight DataArray-like class."""
 
-    __slots__ = ["attrs", "coord_dims", "coords", "data", "dims", "future"]
+    __slots__ = ["attrs", "coord_dims", "coords", "_data", "dims", "future"]
 
     def __init__(
         self,
@@ -22,12 +22,29 @@ class LightDataArray:
         attrs: None | dict = None,
     ) -> None:
         """A lightweight DataArray-like class."""
-        self.data = data
+        self._data = data
         self.dims = dims
         self.coords = coords
         self.coord_dims = coord_dims
         self.attrs = attrs or {}
         self.future: None | TensorStoreFuture = None
+
+    @property
+    def data(self) -> np.ndarray | TensorStore:
+        """Return the backing array."""
+        return self._data
+
+    @data.setter
+    def data(self, value: np.ndarray | TensorStore) -> None:
+        """Replace the backing array without changing dimensions."""
+        if value.shape != self.shape:
+            raise ValueError(
+                "Replacement data must match the existing shape. "
+                f"Replacement has shape {value.shape}; existing data has shape {self.shape}.",
+            )
+
+        self._data = value
+        self.future = None
 
     @classmethod
     def from_xarray(cls, da: xr.DataArray) -> "LightDataArray":
@@ -151,27 +168,20 @@ class LightDataArray:
     def load(self) -> "LightDataArray":
         """Load data in-place and return self."""
         self.data = self.values
-        self.future = None
         return self
 
     @property
     def values(self) -> np.ndarray:
-        """Get the underlying data as numpy array, loading it if necessary."""
-        if isinstance(self.data, TensorStore):
-            # If TensorStore handle reading
-            if self.future is None:
-                return np.asarray(self.data.read().result())
-            else:
-                return np.asarray(self.future.result())
-        else:
-            return np.asarray(self.data)
+        """Return the data as a NumPy array, loading it if necessary."""
+        data = self._data
 
+        if not isinstance(data, TensorStore):
+            return np.asarray(data)
 
-    def __getattr__(self, name: str) -> "LightDataArray":
-        """Allow access to coordinates via attribute syntax, e.g., da.time."""
-        if name in self.coords:
-            return self[name]
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+        if self.future is None:
+            return np.asarray(data.read().result())
+
+        return np.asarray(self.future.result())
 
     def __getitem__(self, key: str) -> "LightDataArray":
         """Allow access to coordinates via indexing syntax, e.g., da['time']."""
@@ -187,7 +197,7 @@ class LightDataArray:
     def __getstate__(self) -> dict:
         """Prepare state for pickling, excluding un-picklable attributes."""
         return {
-            "data": self.data,
+            "_data": self._data,
             "dims": self.dims,
             "coords": self.coords,
             "attrs": self.attrs,
@@ -196,8 +206,11 @@ class LightDataArray:
 
     def __setstate__(self, state: dict) -> None:
         """Restore state after unpickling."""
-        for k, v in state.items():
-            setattr(self, k, v)
+        self._data = state["_data"]
+        self.dims = state["dims"]
+        self.coords = state["coords"]
+        self.attrs = state["attrs"]
+        self.coord_dims = state["coord_dims"]
         # Restore the un-picklable attribute to a default state
         self.future = None
 

--- a/src/ocf_data_sampler/common/time_utils.py
+++ b/src/ocf_data_sampler/common/time_utils.py
@@ -135,7 +135,7 @@ def datetime_ceil(
     epoch_datetime = np.datetime64("1970-01-01", "ns")
     periods_since_epoch = np.ceil((datetimes - epoch_datetime) / freq)
     result = ((periods_since_epoch * freq) + epoch_datetime).astype(datetimes.dtype)
-    return cast(np.datetime64 | NDArray[np.datetime64], result)
+    return cast("np.datetime64 | NDArray[np.datetime64]", result)
 
 
 def datetime_floor(
@@ -152,7 +152,7 @@ def datetime_floor(
     epoch_datetime = np.datetime64("1970-01-01", "ns")
     periods_since_epoch = np.floor((datetimes - epoch_datetime) / freq)
     result = ((periods_since_epoch * freq) + epoch_datetime).astype(datetimes.dtype)
-    return cast(np.datetime64 | NDArray[np.datetime64], result)
+    return cast("np.datetime64 | NDArray[np.datetime64]", result)
 
 
 def get_posix_timestamp(

--- a/src/ocf_data_sampler/common/time_utils.py
+++ b/src/ocf_data_sampler/common/time_utils.py
@@ -1,10 +1,8 @@
 """Module for datetime utilities."""
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 from numpy.typing import NDArray
-
-_EPOCH_DATETIME = np.datetime64("1970-01-01", "ns")
 
 
 def minutes(minutes: int | list[int]) -> np.timedelta64 | NDArray[np.timedelta64]:
@@ -74,15 +72,14 @@ def get_day_fraction(
         datetimes: the datetimes to get day fraction for
     """
     day_start = datetimes.astype("datetime64[D]")
-    day_fraction = np.divide(datetimes - day_start, np.timedelta64(1, "D"))
-    if isinstance(datetimes, np.ndarray):
-        return np.asarray(day_fraction, dtype=np.float64)
-    return np.float64(day_fraction)
+    elapsed = cast("Any", datetimes - day_start)
+    day_fraction = (elapsed / np.timedelta64(1, "D")).astype(np.float64)
+    return cast("np.float64 | NDArray[np.float64]", day_fraction)
 
 
 def get_is_leap_year(
     datetimes: np.datetime64 | NDArray[np.datetime64],
-) -> np.bool_ | NDArray[np.bool_]:
+) ->  np.bool_ | NDArray[np.bool_]:
     """Get whether the datetime is in a leap year.
 
     Args:
@@ -90,9 +87,7 @@ def get_is_leap_year(
     """
     years = get_year(datetimes)
     result = (years % 4 == 0) & ((years % 100 != 0) | (years % 400 == 0))
-    if isinstance(datetimes, np.ndarray):
-        return np.asarray(result, dtype=np.bool_)
-    return np.bool_(result)
+    return cast("np.bool_ | NDArray[np.bool_]", result)
 
 
 def date_range(
@@ -137,11 +132,10 @@ def datetime_ceil(
         freq: the frequency to ceil to
     """
     _floor_ceil_check_freq(freq)
-    periods_since_epoch = np.ceil(np.divide(datetimes - _EPOCH_DATETIME, freq))
-    result = (periods_since_epoch * freq) + _EPOCH_DATETIME
-    if isinstance(datetimes, np.ndarray):
-        return np.asarray(result, dtype=datetimes.dtype)
-    return cast("np.datetime64", np.datetime64(result).astype(datetimes.dtype))
+    epoch_datetime = np.datetime64("1970-01-01", "ns")
+    periods_since_epoch = np.ceil((datetimes - epoch_datetime) / freq)
+    result = ((periods_since_epoch * freq) + epoch_datetime).astype(datetimes.dtype)
+    return cast("np.datetime64 | NDArray[np.datetime64]", result)
 
 
 def datetime_floor(
@@ -155,11 +149,10 @@ def datetime_floor(
         freq: the frequency to floor to
     """
     _floor_ceil_check_freq(freq)
-    periods_since_epoch = np.floor(np.divide(datetimes - _EPOCH_DATETIME, freq))
-    result = (periods_since_epoch * freq) + _EPOCH_DATETIME
-    if isinstance(datetimes, np.ndarray):
-        return np.asarray(result, dtype=datetimes.dtype)
-    return cast("np.datetime64", np.datetime64(result).astype(datetimes.dtype))
+    epoch_datetime = np.datetime64("1970-01-01", "ns")
+    periods_since_epoch = np.floor((datetimes - epoch_datetime) / freq)
+    result = ((periods_since_epoch * freq) + epoch_datetime).astype(datetimes.dtype)
+    return cast("np.datetime64 | NDArray[np.datetime64]", result)
 
 
 def get_posix_timestamp(

--- a/src/ocf_data_sampler/common/time_utils.py
+++ b/src/ocf_data_sampler/common/time_utils.py
@@ -1,4 +1,6 @@
 """Module for datetime utilities."""
+from typing import Any, cast
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -54,7 +56,11 @@ def get_day_of_year(
     """
     day_arr = datetimes.astype("datetime64[D]")
     year_start_arr = day_arr.astype("datetime64[Y]").astype("datetime64[D]")
-    return (day_arr - year_start_arr).astype(np.int32) + 1
+
+    day_number = day_arr.astype(np.int64)
+    year_start_number = year_start_arr.astype(np.int64)
+
+    return (day_number - year_start_number).astype(np.int32) + np.int32(1)
 
 
 def get_day_fraction(
@@ -66,7 +72,9 @@ def get_day_fraction(
         datetimes: the datetimes to get day fraction for
     """
     day_start = datetimes.astype("datetime64[D]")
-    return ((datetimes - day_start) / np.timedelta64(1, "D")).astype(np.float64)
+    elapsed = cast("Any", datetimes - day_start)
+    day_fraction = (elapsed / np.timedelta64(1, "D")).astype(np.float64)
+    return cast("np.float64 | NDArray[np.float64]", day_fraction)
 
 
 def get_is_leap_year(
@@ -78,7 +86,8 @@ def get_is_leap_year(
         datetimes: the datetimes to get leap year for
     """
     years = get_year(datetimes)
-    return (years % 4 == 0) & ((years % 100 != 0) | (years % 400 == 0))
+    result = (years % 4 == 0) & ((years % 100 != 0) | (years % 400 == 0))
+    return cast("np.bool_ | NDArray[np.bool_]", result)
 
 
 def date_range(

--- a/src/ocf_data_sampler/common/time_utils.py
+++ b/src/ocf_data_sampler/common/time_utils.py
@@ -1,9 +1,11 @@
 """Module for datetime utilities."""
+from typing import cast
 
 import numpy as np
 from numpy.typing import NDArray
 
 _EPOCH_DATETIME = np.datetime64("1970-01-01", "ns")
+
 
 def minutes(minutes: int | list[int]) -> np.timedelta64 | NDArray[np.timedelta64]:
     """Timedelta minutes.
@@ -139,7 +141,7 @@ def datetime_ceil(
     result = (periods_since_epoch * freq) + _EPOCH_DATETIME
     if isinstance(datetimes, np.ndarray):
         return np.asarray(result, dtype=datetimes.dtype)
-    return np.datetime64(result).astype(datetimes.dtype)
+    return cast("np.datetime64", np.datetime64(result).astype(datetimes.dtype))
 
 
 def datetime_floor(
@@ -157,7 +159,7 @@ def datetime_floor(
     result = (periods_since_epoch * freq) + _EPOCH_DATETIME
     if isinstance(datetimes, np.ndarray):
         return np.asarray(result, dtype=datetimes.dtype)
-    return np.datetime64(result).astype(datetimes.dtype)
+    return cast("np.datetime64", np.datetime64(result).astype(datetimes.dtype))
 
 
 def get_posix_timestamp(

--- a/src/ocf_data_sampler/common/time_utils.py
+++ b/src/ocf_data_sampler/common/time_utils.py
@@ -134,7 +134,8 @@ def datetime_ceil(
     _floor_ceil_check_freq(freq)
     epoch_datetime = np.datetime64("1970-01-01", "ns")
     periods_since_epoch = np.ceil((datetimes - epoch_datetime) / freq)
-    return ((periods_since_epoch * freq) + epoch_datetime).astype(datetimes.dtype)
+    result = ((periods_since_epoch * freq) + epoch_datetime).astype(datetimes.dtype)
+    return cast(np.datetime64 | NDArray[np.datetime64], result)
 
 
 def datetime_floor(
@@ -150,7 +151,8 @@ def datetime_floor(
     _floor_ceil_check_freq(freq)
     epoch_datetime = np.datetime64("1970-01-01", "ns")
     periods_since_epoch = np.floor((datetimes - epoch_datetime) / freq)
-    return ((periods_since_epoch * freq) + epoch_datetime).astype(datetimes.dtype)
+    result = ((periods_since_epoch * freq) + epoch_datetime).astype(datetimes.dtype)
+    return cast(np.datetime64 | NDArray[np.datetime64], result)
 
 
 def get_posix_timestamp(

--- a/src/ocf_data_sampler/common/time_utils.py
+++ b/src/ocf_data_sampler/common/time_utils.py
@@ -1,9 +1,9 @@
 """Module for datetime utilities."""
-from typing import Any, cast
 
 import numpy as np
 from numpy.typing import NDArray
 
+_EPOCH_DATETIME = np.datetime64("1970-01-01", "ns")
 
 def minutes(minutes: int | list[int]) -> np.timedelta64 | NDArray[np.timedelta64]:
     """Timedelta minutes.
@@ -72,14 +72,15 @@ def get_day_fraction(
         datetimes: the datetimes to get day fraction for
     """
     day_start = datetimes.astype("datetime64[D]")
-    elapsed = cast("Any", datetimes - day_start)
-    day_fraction = (elapsed / np.timedelta64(1, "D")).astype(np.float64)
-    return cast("np.float64 | NDArray[np.float64]", day_fraction)
+    day_fraction = np.divide(datetimes - day_start, np.timedelta64(1, "D"))
+    if isinstance(datetimes, np.ndarray):
+        return np.asarray(day_fraction, dtype=np.float64)
+    return np.float64(day_fraction)
 
 
 def get_is_leap_year(
     datetimes: np.datetime64 | NDArray[np.datetime64],
-) ->  np.bool_ | NDArray[np.bool_]:
+) -> np.bool_ | NDArray[np.bool_]:
     """Get whether the datetime is in a leap year.
 
     Args:
@@ -87,7 +88,9 @@ def get_is_leap_year(
     """
     years = get_year(datetimes)
     result = (years % 4 == 0) & ((years % 100 != 0) | (years % 400 == 0))
-    return cast("np.bool_ | NDArray[np.bool_]", result)
+    if isinstance(datetimes, np.ndarray):
+        return np.asarray(result, dtype=np.bool_)
+    return np.bool_(result)
 
 
 def date_range(
@@ -132,10 +135,11 @@ def datetime_ceil(
         freq: the frequency to ceil to
     """
     _floor_ceil_check_freq(freq)
-    epoch_datetime = np.datetime64("1970-01-01", "ns")
-    periods_since_epoch = np.ceil((datetimes - epoch_datetime) / freq)
-    result = ((periods_since_epoch * freq) + epoch_datetime).astype(datetimes.dtype)
-    return cast("np.datetime64 | NDArray[np.datetime64]", result)
+    periods_since_epoch = np.ceil(np.divide(datetimes - _EPOCH_DATETIME, freq))
+    result = (periods_since_epoch * freq) + _EPOCH_DATETIME
+    if isinstance(datetimes, np.ndarray):
+        return np.asarray(result, dtype=datetimes.dtype)
+    return np.datetime64(result).astype(datetimes.dtype)
 
 
 def datetime_floor(
@@ -149,10 +153,11 @@ def datetime_floor(
         freq: the frequency to floor to
     """
     _floor_ceil_check_freq(freq)
-    epoch_datetime = np.datetime64("1970-01-01", "ns")
-    periods_since_epoch = np.floor((datetimes - epoch_datetime) / freq)
-    result = ((periods_since_epoch * freq) + epoch_datetime).astype(datetimes.dtype)
-    return cast("np.datetime64 | NDArray[np.datetime64]", result)
+    periods_since_epoch = np.floor(np.divide(datetimes - _EPOCH_DATETIME, freq))
+    result = (periods_since_epoch * freq) + _EPOCH_DATETIME
+    if isinstance(datetimes, np.ndarray):
+        return np.asarray(result, dtype=datetimes.dtype)
+    return np.datetime64(result).astype(datetimes.dtype)
 
 
 def get_posix_timestamp(

--- a/src/ocf_data_sampler/common/types.py
+++ b/src/ocf_data_sampler/common/types.py
@@ -1,0 +1,43 @@
+from typing import Any, Protocol, Self, TypeVar
+from numpy.typing import NDArray
+
+
+class DataArrayLike(Protocol):
+    """A protocol for objects that behave like xarray.DataArray."""
+
+    @property
+    def dims(self) -> tuple[str, ...]:
+        ...
+
+    @property
+    def data(self) -> Any:
+        """Return the underlying NumPy or lazy backend array."""
+        ...
+
+    @data.setter
+    def data(self, value: NDArray[Any]) -> None: 
+        ...
+
+    @property
+    def values(self) -> NDArray[Any]:
+        ...
+
+    def isel(self, **indexers: Any) -> Self:
+        ...
+
+    def __getitem__(self, key: Any) -> Self:
+        ...
+
+    def load(self) -> Self:
+        ...
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        ...
+
+    @property
+    def __len__(self) -> int:
+        ...
+
+
+TArray = TypeVar("TArray", bound=DataArrayLike)

--- a/src/ocf_data_sampler/common/types.py
+++ b/src/ocf_data_sampler/common/types.py
@@ -1,43 +1,70 @@
-from typing import Any, Protocol, Self, TypeVar
+"""The array contract shared by ``xarray.DataArray`` and ``LightDataArray``.
+
+``DataArrayLike`` defines the duck-typed surface the sampling pipeline is
+allowed to use on array objects. It is deliberately minimal: every member is
+an obligation on ``LightDataArray`` and a promise that ``xarray.DataArray``
+also satisfies. Do not add members without checking that both implementations
+conform (see the protocol conformance test) — this is the array-compatibility
+contract, not a convenience grab-bag.
+"""
+
+from collections.abc import Hashable, Sequence
+from typing import Any, Protocol, Self, TypeAlias, TypeVar
+
+import numpy as np
 from numpy.typing import NDArray
+
+# Types accepted as a single-dimension indexer in `.isel()` method below.
+Indexer: TypeAlias = int | slice | Sequence[int] | NDArray[np.integer]
 
 
 class DataArrayLike(Protocol):
-    """A protocol for objects that behave like xarray.DataArray."""
+    """Structural type for objects that behave like ``xarray.DataArray``.
+
+    Satisfied by ``xarray.DataArray`` and ``LightDataArray``. Pipeline code
+    that is generic over the array backend should be typed against this
+    protocol — usually via ``TArray`` so the concrete type is preserved
+    through the pipeline — rather than against either concrete class.
+    """
 
     @property
-    def dims(self) -> tuple[str, ...]:
-        ...
+    def dims(self) -> tuple[Hashable, ...]:
+        """Dimension names in data order (``Hashable`` to match xarray's typing)."""
 
     @property
-    def data(self) -> Any:
-        """Return the underlying NumPy or lazy backend array."""
-        ...
+    def data(self) -> Any:  # noqa: ANN401 - the backend is intentionally open: numpy, TensorStore, dask, ...
+        """The backing array: numpy, TensorStore, or any duck array."""
 
     @data.setter
-    def data(self, value: NDArray[Any]) -> None: 
-        ...
+    def data(self, value: NDArray[Any]) -> None:
+        """Rebind the backing array; the shape must match the existing data."""
 
     @property
     def values(self) -> NDArray[Any]:
-        ...
-
-    def isel(self, **indexers: Any) -> Self:
-        ...
-
-    def __getitem__(self, key: Any) -> Self:
-        ...
-
-    def load(self) -> Self:
-        ...
+        """The data as a numpy array, loading/computing it if necessary."""
 
     @property
     def shape(self) -> tuple[int, ...]:
-        ...
+        """Shape of the backing array."""
 
-    @property
+    def isel(
+        self,
+        indexers: dict[str, Indexer] | None = None,
+        **indexers_kwargs: Any,  # noqa: ANN401 - must stay Any: xarray's isel has non-indexer
+        # keyword params (drop, missing_dims) whose types conflict with any narrower
+        # annotation here; see Indexer for the types actually passed.
+    ) -> Self:
+        """Select by integer position along named dimensions (see ``Indexer``)."""
+
+    def __getitem__(self, key: str) -> Self:
+        """Return the named coordinate as an array-like."""
+
+    def load(self) -> Self:
+        """Load the data into memory in place and return self."""
+
     def __len__(self) -> int:
-        ...
+        """Length of the leading dimension."""
 
 
+# Used to type functions that return the same kind of DataArray-like object they receive.
 TArray = TypeVar("TArray", bound=DataArrayLike)

--- a/src/ocf_data_sampler/common/xr_tensorstore.py
+++ b/src/ocf_data_sampler/common/xr_tensorstore.py
@@ -17,6 +17,7 @@ References:
 import logging
 import os.path
 import re
+from typing import Any, cast
 
 import tensorstore as ts
 import xarray as xr
@@ -29,11 +30,12 @@ from xarray_tensorstore import (
 
 logger = logging.getLogger(__name__)
 
-def _zarr_spec_from_path(path: str, zarr_format: int) -> ...:
+
+def _zarr_spec_from_path(path: str, zarr_format: int) -> dict[str, Any]:
     if re.match(r"\w+\://", path):  # path is a URI
-      kv_store = path
+        kv_store: str | dict[str, str] = path
     else:
-      kv_store = {"driver": _DEFAULT_STORAGE_DRIVER, "path": path}
+        kv_store = {"driver": _DEFAULT_STORAGE_DRIVER, "path": path}
     return {"driver": f"zarr{zarr_format}", "kvstore": kv_store}
 
 
@@ -41,7 +43,7 @@ def _get_data_variable_array_futures(
     path: str,
     context: ts.Context | None,
     variables: list[str],
-) -> dict[ts.Future]:
+) -> dict[str, ts.Future[ts.TensorStore]]:
     """Open all data variables in a zarr group and return futures.
 
     Args:
@@ -113,15 +115,15 @@ def open_zarr(
 
     # Open all data variables using tensorstore - returned as futures
     data_vars = list(ds.data_vars)
-    arrays = _get_data_variable_array_futures(path, context, data_vars)
+    array_futures = _get_data_variable_array_futures(path, context, data_vars)
 
     # Wait for the async open operations
-    arrays = {k: v.result() for k, v in arrays.items()}
+    arrays = {k: future.result() for k, future in array_futures.items()}
 
     # Adapt the tensorstore arrays and plug them into the xarray object
     new_data = {k: _TensorStoreAdapter(v) for k, v in arrays.items()}
 
-    return ds.copy(data=new_data)
+    return cast("xr.Dataset", ds.copy(data=new_data))
 
 
 def open_zarrs(
@@ -186,4 +188,4 @@ def open_zarrs(
     # Plug the arrays into the xarray object
     new_data = {k: _TensorStoreAdapter(v) for k, v in arrays.items()}
 
-    return ds.copy(data=new_data)
+    return cast("xr.Dataset", ds.copy(data=new_data))

--- a/src/ocf_data_sampler/common/xr_tensorstore.py
+++ b/src/ocf_data_sampler/common/xr_tensorstore.py
@@ -17,7 +17,7 @@ References:
 import logging
 import os.path
 import re
-from typing import Any
+from typing import Any, cast
 
 import tensorstore as ts
 import xarray as xr
@@ -29,15 +29,6 @@ from xarray_tensorstore import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _get_data_var_names(ds: xr.Dataset) -> list[str]:
-    data_vars: list[str] = []
-    for name in ds.data_vars:
-        if not isinstance(name, str):
-            raise TypeError(f"Zarr data variable names must be strings, got {name!r}")
-        data_vars.append(name)
-    return data_vars
 
 
 def _zarr_spec_from_path(path: str, zarr_format: int) -> dict[str, Any]:
@@ -120,15 +111,13 @@ def open_zarr(
         context = ts.Context()
 
     # Avoid using dask by settung `chunks=None`
-    ds: xr.Dataset = xr.open_zarr(
-        path, chunks=None, mask_and_scale=mask_and_scale, consolidated=False
-    )
+    ds = xr.open_zarr(path, chunks=None, mask_and_scale=mask_and_scale, consolidated=False)
 
     if mask_and_scale:
         _raise_if_mask_and_scale_used_for_data_vars(ds)
 
     # Open all data variables using tensorstore - returned as futures
-    data_vars = _get_data_var_names(ds)
+    data_vars = list(ds.data_vars)
     array_futures = _get_data_variable_array_futures(path, context, data_vars)
 
     # Wait for the async open operations
@@ -137,7 +126,7 @@ def open_zarr(
     # Adapt the tensorstore arrays and plug them into the xarray object
     new_data = {k: _TensorStoreAdapter(v) for k, v in arrays.items()}
 
-    return ds.copy(data=new_data)
+    return cast("xr.Dataset", ds.copy(data=new_data))
 
 
 def open_zarrs(
@@ -162,11 +151,10 @@ def open_zarrs(
     if context is None:
         context = ts.Context()
 
-    ds_list: list[xr.Dataset] = [
+    ds_list = [
         xr.open_zarr(p, mask_and_scale=mask_and_scale, decode_timedelta=True, consolidated=False)
         for p in paths
     ]
-    ds: xr.Dataset
     try:
         ds = xr.concat(
             ds_list,
@@ -195,7 +183,7 @@ def open_zarrs(
         _raise_if_mask_and_scale_used_for_data_vars(ds)
 
     # Find the axis along which each data array must be concatenated
-    data_vars = _get_data_var_names(ds)
+    data_vars = list(ds.data_vars)
     concat_axes = [ds[v].dims.index(concat_dim) for v in data_vars]
 
     # Open and concat all zarrs so each variables is a single TensorStore array
@@ -204,4 +192,4 @@ def open_zarrs(
     # Plug the arrays into the xarray object
     new_data = {k: _TensorStoreAdapter(v) for k, v in arrays.items()}
 
-    return ds.copy(data=new_data)
+    return cast("xr.Dataset", ds.copy(data=new_data))

--- a/src/ocf_data_sampler/common/xr_tensorstore.py
+++ b/src/ocf_data_sampler/common/xr_tensorstore.py
@@ -17,7 +17,7 @@ References:
 import logging
 import os.path
 import re
-from typing import Any, cast
+from typing import Any
 
 import tensorstore as ts
 import xarray as xr
@@ -111,7 +111,9 @@ def open_zarr(
         context = ts.Context()
 
     # Avoid using dask by settung `chunks=None`
-    ds = xr.open_zarr(path, chunks=None, mask_and_scale=mask_and_scale, consolidated=False)
+    ds: xr.Dataset = xr.open_zarr(
+        path, chunks=None, mask_and_scale=mask_and_scale, consolidated=False
+    )
 
     if mask_and_scale:
         _raise_if_mask_and_scale_used_for_data_vars(ds)
@@ -126,7 +128,7 @@ def open_zarr(
     # Adapt the tensorstore arrays and plug them into the xarray object
     new_data = {k: _TensorStoreAdapter(v) for k, v in arrays.items()}
 
-    return cast("xr.Dataset", ds.copy(data=new_data))
+    return ds.copy(data=new_data)
 
 
 def open_zarrs(
@@ -151,10 +153,11 @@ def open_zarrs(
     if context is None:
         context = ts.Context()
 
-    ds_list = [xr.open_zarr(p,
-                            mask_and_scale=mask_and_scale,
-                            decode_timedelta=True,
-                            consolidated=False) for p in paths]
+    ds_list: list[xr.Dataset] = [
+        xr.open_zarr(p, mask_and_scale=mask_and_scale, decode_timedelta=True, consolidated=False)
+        for p in paths
+    ]
+    ds: xr.Dataset
     try:
         ds = xr.concat(
             ds_list,
@@ -165,10 +168,11 @@ def open_zarrs(
             join="exact",
         )
     except ValueError:
-        logger.warning(f"Coordinate mismatch found in {data_source} input data. "
-                       f"The coordinates will be overwritten! "
-                       f"This might be fine for satellite data. "
-                       f"Proceed with caution.")
+        logger.warning(
+            f"Coordinate mismatch found in {data_source} input data. Opening with "
+            "`join='override'` to ignore coordinate mismatches. THIS MAY CAUSE UNEXPECTED "
+            "BEHAVIOUR!",
+        )
         ds = xr.concat(
             ds_list,
             dim=concat_dim,
@@ -191,4 +195,4 @@ def open_zarrs(
     # Plug the arrays into the xarray object
     new_data = {k: _TensorStoreAdapter(v) for k, v in arrays.items()}
 
-    return cast("xr.Dataset", ds.copy(data=new_data))
+    return ds.copy(data=new_data)

--- a/src/ocf_data_sampler/common/xr_tensorstore.py
+++ b/src/ocf_data_sampler/common/xr_tensorstore.py
@@ -31,6 +31,15 @@ from xarray_tensorstore import (
 logger = logging.getLogger(__name__)
 
 
+def _get_data_var_names(ds: xr.Dataset) -> list[str]:
+    data_vars: list[str] = []
+    for name in ds.data_vars:
+        if not isinstance(name, str):
+            raise TypeError(f"Zarr data variable names must be strings, got {name!r}")
+        data_vars.append(name)
+    return data_vars
+
+
 def _zarr_spec_from_path(path: str, zarr_format: int) -> dict[str, Any]:
     if re.match(r"\w+\://", path):  # path is a URI
         kv_store: str | dict[str, str] = path
@@ -119,7 +128,7 @@ def open_zarr(
         _raise_if_mask_and_scale_used_for_data_vars(ds)
 
     # Open all data variables using tensorstore - returned as futures
-    data_vars = list(ds.data_vars)
+    data_vars = _get_data_var_names(ds)
     array_futures = _get_data_variable_array_futures(path, context, data_vars)
 
     # Wait for the async open operations
@@ -186,7 +195,7 @@ def open_zarrs(
         _raise_if_mask_and_scale_used_for_data_vars(ds)
 
     # Find the axis along which each data array must be concatenated
-    data_vars = list(ds.data_vars)
+    data_vars = _get_data_var_names(ds)
     concat_axes = [ds[v].dims.index(concat_dim) for v in data_vars]
 
     # Open and concat all zarrs so each variables is a single TensorStore array

--- a/src/ocf_data_sampler/common/xr_tensorstore.py
+++ b/src/ocf_data_sampler/common/xr_tensorstore.py
@@ -71,15 +71,18 @@ def _tensorstore_open_zarrs(
         context: TensorStore context.
     """
     # Open all the variables from all the datasets - returned as futures
-    arrays_list: list[dict[str, ts.Future]] = []
+    array_futures_list: list[dict[str, ts.Future[ts.TensorStore]]] = []
     for path in paths:
-        arrays_list.append(_get_data_variable_array_futures(path, context, data_vars))
+        array_futures_list.append(_get_data_variable_array_futures(path, context, data_vars))
 
     # Wait for the async open operations
-    arrays_list = [{k: v.result() for k, v in arrays.items()} for arrays in arrays_list]
+    arrays_list: list[dict[str, ts.TensorStore]] = [
+        {k: future.result() for k, future in array_futures.items()}
+        for array_futures in array_futures_list
+    ]
 
     # Concatenate each of the variables along the required axis
-    arrays = {}
+    arrays: dict[str, ts.TensorStore] = {}
     for k, axis in zip(data_vars, concat_axes, strict=True):
         variable_arrays = [d[k] for d in arrays_list]
         arrays[k] = ts.concat(variable_arrays, axis=axis)

--- a/src/ocf_data_sampler/datasets/pvnet/dataset.py
+++ b/src/ocf_data_sampler/datasets/pvnet/dataset.py
@@ -24,8 +24,6 @@ from ocf_data_sampler.datasets.pvnet.preprocess import (
     fill_nans_in_dataset_dicts,
 )
 from ocf_data_sampler.datasets.pvnet.sample import (
-    NumpySample,
-    TensorBatch,
     convert_to_numpy_sample,
     make_sun_position_numpy_sample,
     make_t0_encoding_numpy_sample,
@@ -43,6 +41,8 @@ from ocf_data_sampler.select import (
     intersection_of_multiple_dataframes_of_periods,
 )
 from ocf_data_sampler.spatial import Location, convert_coordinates, find_coord_system
+from ocf_data_sampler.datasets.pvnet.types import SourceDict, TensorBatch, NumpySample
+
 
 # Ignore pydantic warning which doesn't cause an issue
 warnings.filterwarnings("ignore", category=UnsupportedFieldAttributeWarning)
@@ -60,14 +60,14 @@ def get_locations(generation_data: xr.DataArray) -> list[Location]:
         generation_data: xarray dataarray of generation data with location info
     """
     locations = []
-    location_ids = generation_data.location_id.values
+    location_ids = generation_data["location_id"].values
 
     for location_id in location_ids:
         gen_data = generation_data.sel(location_id=location_id)
         locations.append(
             Location(
-                x=gen_data.longitude.values,
-                y=gen_data.latitude.values,
+                x=gen_data["longitude"].values,
+                y=gen_data["latitude"].values,
                 coord_system="lon_lat",
                 id=int(location_id),
             ),
@@ -76,7 +76,9 @@ def get_locations(generation_data: xr.DataArray) -> list[Location]:
     return locations
 
 
-def xarray_to_lightarray_dict(dataset_dict: dict) -> dict:
+def xarray_to_lightarray_dict(
+    dataset_dict: SourceDict[xr.DataArray],
+) -> SourceDict[LightDataArray]:
     """Create a dictionary LightDataArrays from a dictionary of xarray datasets."""
     new_dataset_dict = {}
     for k, v in dataset_dict.items():
@@ -116,7 +118,7 @@ def get_time_periods_mask(
 
 def add_alternate_coordinate_projections(
     locations: list[Location],
-    datasets_dict: dict,
+    datasets_dict: SourceDict,
 ) -> list[Location]:
     """Add (in-place) coordinate projections for all dataset to a set of locations.
 
@@ -254,7 +256,7 @@ class AbstractPVNetDataset(PickleCacheMixin, Dataset):
 
     def process_and_combine_datasets(
         self,
-        dataset_dict: dict,
+        dataset_dict: SourceDict,
         t0: np.datetime64,
         location: Location,
     ) -> NumpySample:
@@ -326,8 +328,8 @@ class AbstractPVNetDataset(PickleCacheMixin, Dataset):
             sample.update(
                 make_sun_position_numpy_sample(
                     datetimes,
-                    dataset_dict["generation"].longitude.values,
-                    dataset_dict["generation"].latitude.values,
+                    dataset_dict["generation"]["longitude"].values,
+                    dataset_dict["generation"]["latitude"].values,
                 ),
             )
 
@@ -336,7 +338,10 @@ class AbstractPVNetDataset(PickleCacheMixin, Dataset):
         return sample
 
     @staticmethod
-    def find_valid_t0_times(datasets_dict: dict, config: Configuration) -> NDArray[np.datetime64]:
+    def find_valid_t0_times(
+        datasets_dict: SourceDict,
+        config: Configuration
+    ) -> NDArray[np.datetime64]:
         """Find the t0 times where all of the requested input data is available.
 
         Args:
@@ -354,7 +359,7 @@ class AbstractPVNetDataset(PickleCacheMixin, Dataset):
 
     @staticmethod
     def find_valid_t0_and_location_ids(
-        datasets_dict: dict,
+        datasets_dict: SourceDict,
         config: Configuration,
     ) -> pd.DataFrame:
         """Find the t0 times where all of the requested input data is available for each location.
@@ -383,7 +388,7 @@ class AbstractPVNetDataset(PickleCacheMixin, Dataset):
 
             # Obtain valid time periods for this location
             time_periods = find_contiguous_t0_periods(
-                generation.time_utc.values,
+                generation["time_utc"].values,
                 time_resolution=minutes(generation_config.time_resolution_minutes),
                 interval_start=minutes(generation_config.interval_start_minutes),
                 interval_end=minutes(generation_config.interval_end_minutes),

--- a/src/ocf_data_sampler/datasets/pvnet/dataset.py
+++ b/src/ocf_data_sampler/datasets/pvnet/dataset.py
@@ -33,6 +33,7 @@ from ocf_data_sampler.datasets.pvnet.slicing import (
     slice_datasets_by_space,
     slice_datasets_by_time,
 )
+from ocf_data_sampler.datasets.pvnet.types import NumpySample, SourceDict, TensorBatch
 from ocf_data_sampler.datasets.pvnet.valid_t0s import find_valid_time_periods
 from ocf_data_sampler.features.time_encodings import encode_datetimes
 from ocf_data_sampler.select import (
@@ -41,8 +42,6 @@ from ocf_data_sampler.select import (
     intersection_of_multiple_dataframes_of_periods,
 )
 from ocf_data_sampler.spatial import Location, convert_coordinates, find_coord_system
-from ocf_data_sampler.datasets.pvnet.types import SourceDict, TensorBatch, NumpySample
-
 
 # Ignore pydantic warning which doesn't cause an issue
 warnings.filterwarnings("ignore", category=UnsupportedFieldAttributeWarning)
@@ -340,7 +339,7 @@ class AbstractPVNetDataset(PickleCacheMixin, Dataset):
     @staticmethod
     def find_valid_t0_times(
         datasets_dict: SourceDict,
-        config: Configuration
+        config: Configuration,
     ) -> NDArray[np.datetime64]:
         """Find the t0 times where all of the requested input data is available.
 

--- a/src/ocf_data_sampler/datasets/pvnet/loading.py
+++ b/src/ocf_data_sampler/datasets/pvnet/loading.py
@@ -5,9 +5,8 @@ import logging
 import xarray as xr
 
 from ocf_data_sampler.config import InputData
-from ocf_data_sampler.load import open_generation, open_nwp, open_sat_data
 from ocf_data_sampler.datasets.pvnet.types import SourceDict
-
+from ocf_data_sampler.load import open_generation, open_nwp, open_sat_data
 
 logger = logging.getLogger(__name__)
 

--- a/src/ocf_data_sampler/datasets/pvnet/loading.py
+++ b/src/ocf_data_sampler/datasets/pvnet/loading.py
@@ -6,13 +6,13 @@ import xarray as xr
 
 from ocf_data_sampler.config import InputData
 from ocf_data_sampler.load import open_generation, open_nwp, open_sat_data
+from ocf_data_sampler.datasets.pvnet.types import SourceDict
+
 
 logger = logging.getLogger(__name__)
 
 
-def get_dataset_dict(
-    input_config: InputData,
-) -> dict[str, dict[xr.DataArray] | xr.DataArray]:
+def get_dataset_dict(input_config: InputData) -> SourceDict[xr.DataArray]:
     """Construct dictionary of all of the input data sources.
 
     Args:
@@ -28,8 +28,8 @@ def get_dataset_dict(
         )
 
         # Remove location_id 0 if more than one location present
-        if len(da_generation.location_id) > 1 and 0 in da_generation.location_id.values:
-            da_generation = da_generation.sel(location_id=slice(1, None))
+        if len(da_generation["location_id"]) > 1 and 0 in da_generation["location_id"].values:
+            da_generation = da_generation.drop_sel(location_id=0)
             logger.info(
                 "Id 0 has been filtered out, this is only used for summation models.",
             )

--- a/src/ocf_data_sampler/datasets/pvnet/materialise.py
+++ b/src/ocf_data_sampler/datasets/pvnet/materialise.py
@@ -4,9 +4,10 @@ import numpy as np
 from xarray_tensorstore import read as xtr_read
 
 from ocf_data_sampler.common.lightarray import LightDataArray
+from ocf_data_sampler.datasets.pvnet.types import SourceDict
 
 
-def load(xarray_dict: dict) -> dict:
+def load(xarray_dict: SourceDict) -> SourceDict:
     """Eagerly load a nested dictionary of xarray DataArrays."""
     # Check the generation data is loaded
     if "generation" in xarray_dict and not isinstance(xarray_dict["generation"].data, np.ndarray):
@@ -23,7 +24,7 @@ def load(xarray_dict: dict) -> dict:
     return xarray_dict
 
 
-def read_data_dict(xarray_dict: dict) -> dict:
+def read_data_dict(xarray_dict: SourceDict) -> SourceDict:
     """Start reading a nested dictionary of DataArrays."""
     # Kick off the tensorstore async reading
     for k, v in xarray_dict.items():
@@ -37,7 +38,7 @@ def read_data_dict(xarray_dict: dict) -> dict:
     return xarray_dict
 
 
-def load_data_dict(xarray_dict: dict) -> dict:
+def load_data_dict(xarray_dict: SourceDict) -> SourceDict:
     """Eagerly read and load a nested dictionary of DataArrays."""
     return load(read_data_dict(xarray_dict))
 

--- a/src/ocf_data_sampler/datasets/pvnet/preprocess.py
+++ b/src/ocf_data_sampler/datasets/pvnet/preprocess.py
@@ -2,10 +2,10 @@
 
 import numpy as np
 
-from ocf_data_sampler.config.model import Configuration
-from ocf_data_sampler.features.diff_channels import diff_channels
 from ocf_data_sampler.common.types import TArray
+from ocf_data_sampler.config.model import Configuration
 from ocf_data_sampler.datasets.pvnet.types import SourceDict
+from ocf_data_sampler.features.diff_channels import diff_channels
 
 
 def config_normalization_values_to_dicts(

--- a/src/ocf_data_sampler/datasets/pvnet/preprocess.py
+++ b/src/ocf_data_sampler/datasets/pvnet/preprocess.py
@@ -1,10 +1,11 @@
 """Functions for normalising, differencing, and filling missing values in PVNet input data."""
 
 import numpy as np
-import xarray as xr
 
 from ocf_data_sampler.config.model import Configuration
 from ocf_data_sampler.features.diff_channels import diff_channels
+from ocf_data_sampler.common.types import TArray
+from ocf_data_sampler.datasets.pvnet.types import SourceDict
 
 
 def config_normalization_values_to_dicts(
@@ -82,7 +83,7 @@ def config_normalization_values_to_dicts(
     return means_dict, stds_dict, clip_min_dict, clip_max_dict
 
 
-def diff_nwp_data(dataset_dict: dict, config: Configuration) -> dict:
+def diff_nwp_data(dataset_dict: SourceDict, config: Configuration) -> SourceDict:
     """Take the in-place diff of some channels of the NWP data.
 
     Args:
@@ -98,7 +99,7 @@ def diff_nwp_data(dataset_dict: dict, config: Configuration) -> dict:
     return dataset_dict
 
 
-def fill_nans_in_dataset_dicts(datasets_dict: dict, config: Configuration) -> dict:
+def fill_nans_in_dataset_dicts(datasets_dict: SourceDict, config: Configuration) -> SourceDict:
     """Fills all NaN values in the dataarrays in-place.
 
     Args:
@@ -125,8 +126,8 @@ def fill_nans_in_dataset_dicts(datasets_dict: dict, config: Configuration) -> di
     return datasets_dict
 
 
-def fill_nans(da: xr.DataArray, fill_value: float) -> xr.DataArray:
+def fill_nans(da: TArray, fill_value: float) -> TArray:
     """Fill NaNs in a DataArray in-place."""
     if np.isnan(da.data).any():
-        da.data = np.nan_to_num(da.data, copy=False, nan=fill_value)
+        da.data = np.nan_to_num(da.data, copy=True, nan=fill_value)
     return da

--- a/src/ocf_data_sampler/datasets/pvnet/sample.py
+++ b/src/ocf_data_sampler/datasets/pvnet/sample.py
@@ -3,9 +3,9 @@
 import numpy as np
 from numpy.typing import NDArray
 
+from ocf_data_sampler.datasets.pvnet.types import NumpySample, SourceDict
 from ocf_data_sampler.features.solar import calculate_azimuth_and_elevation
 from ocf_data_sampler.features.time_encodings import encode_t0
-from ocf_data_sampler.datasets.pvnet.types import NumpySample, SourceDict
 
 
 def convert_to_numpy_sample(

--- a/src/ocf_data_sampler/datasets/pvnet/sample.py
+++ b/src/ocf_data_sampler/datasets/pvnet/sample.py
@@ -1,22 +1,15 @@
 """Functions to convert xarray datasets to numpy samples."""
 
-from typing import TypeAlias
-
 import numpy as np
-import torch
-import xarray as xr
 from numpy.typing import NDArray
 
 from ocf_data_sampler.features.solar import calculate_azimuth_and_elevation
 from ocf_data_sampler.features.time_encodings import encode_t0
-
-NumpySample: TypeAlias = dict[str, np.ndarray]
-NumpyBatch: TypeAlias = dict[str, np.ndarray]
-TensorBatch: TypeAlias = dict[str, torch.Tensor]
+from ocf_data_sampler.datasets.pvnet.types import NumpySample, SourceDict
 
 
 def convert_to_numpy_sample(
-    datasets_dict: dict[str, xr.DataArray | dict[str, xr.DataArray]],
+    datasets_dict: SourceDict,
     t0_idx: int,
     include_extra_metadata: bool = False,
 ) -> NumpySample:
@@ -40,8 +33,8 @@ def convert_to_numpy_sample(
         da = datasets_dict["generation"]
 
         # Get the position index of the generation and capacities
-        gen_idx = np.argmax(da.gen_param.values=="generation_mw")
-        cap_idx = np.argmax(da.gen_param.values=="capacity_mwp")
+        gen_idx = np.argmax(da["gen_param"].values == "generation_mw")
+        cap_idx = np.argmax(da["gen_param"].values == "capacity_mwp")
 
         generation_values = da.isel(gen_param=gen_idx).values
         capacity_value = da.isel(gen_param=cap_idx).values[0]
@@ -54,15 +47,15 @@ def convert_to_numpy_sample(
                 "generation": generation_values,
                 "capacity_mwp": capacity_value,
                 "generation_t0_idx": int(t0_idx),
-                "generation_time_utc": da.time_utc.values.astype(float),
+                "generation_time_utc": da["time_utc"].values.astype(float),
             },
         )
 
         if include_extra_metadata:
             numpy_sample.update(
                 {
-                    "location_longitude": float(da.longitude.values),
-                    "location_latitude": float(da.latitude.values),
+                    "location_longitude": float(da["longitude"].values),
+                    "location_latitude": float(da["latitude"].values),
                 },
             )
 
@@ -73,9 +66,9 @@ def convert_to_numpy_sample(
         if include_extra_metadata:
             numpy_sample.update(
                 {
-                    "satellite_time_utc": da.time_utc.values.astype(float),
-                    "satellite_x_geostationary": da.x_geostationary.values,
-                    "satellite_y_geostationary": da.y_geostationary.values,
+                    "satellite_time_utc": da["time_utc"].values.astype(float),
+                    "satellite_x_geostationary": da["x_geostationary"].values,
+                    "satellite_y_geostationary": da["y_geostationary"].values,
                 },
             )
 
@@ -85,11 +78,11 @@ def convert_to_numpy_sample(
             numpy_sample.update({nwp_key: da.values})
 
             if include_extra_metadata:
-                step_hours = (da.step.values / np.timedelta64(1, "h")).astype(float)
-                target_times = (da.init_time_utc.values + da.step.values).astype(float)
+                step_hours = (da["step"].values / np.timedelta64(1, "h")).astype(float)
+                target_times = (da["init_time_utc"].values + da["step"].values).astype(float)
 
                 numpy_sample.update({
-                    f"{nwp_key}_init_time_utc": da.init_time_utc.values.astype(float),
+                    f"{nwp_key}_init_time_utc": da["init_time_utc"].values.astype(float),
                     f"{nwp_key}_step_hours": step_hours,
                     f"{nwp_key}_target_time_utc": target_times,
                 })

--- a/src/ocf_data_sampler/datasets/pvnet/slicing.py
+++ b/src/ocf_data_sampler/datasets/pvnet/slicing.py
@@ -12,13 +12,14 @@ from ocf_data_sampler.select.spatial_slice import (
 )
 from ocf_data_sampler.select.time_slice import select_time_slice, select_time_slice_nwp
 from ocf_data_sampler.spatial import Location
+from ocf_data_sampler.datasets.pvnet.types import SourceDict
 
 
 def slice_datasets_by_space(
-    datasets_dict: dict,
+    datasets_dict: SourceDict,
     location: Location,
     config: Configuration,
-) -> dict:
+) -> SourceDict:
     """Slice the dictionary of input data sources around a given location.
 
     Args:
@@ -56,7 +57,7 @@ def slice_datasets_by_space(
 
     if "generation" in datasets_dict:
 
-        location_ids = datasets_dict["generation"].location_id.values
+        location_ids = datasets_dict["generation"]["location_id"].values
         loc_index = get_indices_in_sorted_unique(location_ids, location.id)
 
         sliced_datasets_dict["generation"] = datasets_dict["generation"].isel(location_id=loc_index)
@@ -65,10 +66,10 @@ def slice_datasets_by_space(
 
 
 def reduce_spatial_extent_of_datasets(
-    datasets_dict: dict,
+    datasets_dict: SourceDict,
     locations: list[Location],
     config: Configuration,
-) -> dict:
+) -> SourceDict:
     """Reduce the spatial extent of the datasets to only cover the locations.
 
     Args:
@@ -107,10 +108,10 @@ def reduce_spatial_extent_of_datasets(
 
 
 def slice_datasets_by_time(
-    datasets_dict: dict,
+    datasets_dict: SourceDict,
     t0: np.datetime64,
     config: Configuration,
-) -> dict:
+) -> SourceDict:
     """Slice the dictionary of input data sources around a given t0 time.
 
     Args:

--- a/src/ocf_data_sampler/datasets/pvnet/slicing.py
+++ b/src/ocf_data_sampler/datasets/pvnet/slicing.py
@@ -5,6 +5,7 @@ import numpy as np
 from ocf_data_sampler.common.indexing import get_indices_in_sorted_unique
 from ocf_data_sampler.common.time_utils import minutes
 from ocf_data_sampler.config.model import Configuration
+from ocf_data_sampler.datasets.pvnet.types import SourceDict
 from ocf_data_sampler.select.dropout import apply_history_dropout
 from ocf_data_sampler.select.spatial_slice import (
     select_spatial_slice_pixels,
@@ -12,7 +13,6 @@ from ocf_data_sampler.select.spatial_slice import (
 )
 from ocf_data_sampler.select.time_slice import select_time_slice, select_time_slice_nwp
 from ocf_data_sampler.spatial import Location
-from ocf_data_sampler.datasets.pvnet.types import SourceDict
 
 
 def slice_datasets_by_space(

--- a/src/ocf_data_sampler/datasets/pvnet/types.py
+++ b/src/ocf_data_sampler/datasets/pvnet/types.py
@@ -1,8 +1,10 @@
 """Types for PVNet dataset orchestration."""
 
 from typing import TypeAlias
+
 import numpy as np
 import torch
+
 from ocf_data_sampler.common.types import TArray
 
 SourceDict: TypeAlias = dict[str, TArray | dict[str, TArray]]

--- a/src/ocf_data_sampler/datasets/pvnet/types.py
+++ b/src/ocf_data_sampler/datasets/pvnet/types.py
@@ -1,0 +1,11 @@
+"""Types for PVNet dataset orchestration."""
+
+from typing import TypeAlias
+import numpy as np
+import torch
+from ocf_data_sampler.common.types import TArray
+
+SourceDict: TypeAlias = dict[str, TArray | dict[str, TArray]]
+NumpySample: TypeAlias = dict[str, np.ndarray | dict[str, np.ndarray]]
+NumpyBatch: TypeAlias = dict[str, np.ndarray | dict[str, np.ndarray]]
+TensorBatch: TypeAlias = dict[str, torch.Tensor | dict[str, torch.Tensor]]

--- a/src/ocf_data_sampler/datasets/pvnet/valid_t0s.py
+++ b/src/ocf_data_sampler/datasets/pvnet/valid_t0s.py
@@ -5,17 +5,17 @@ import pandas as pd
 
 from ocf_data_sampler.common.time_utils import minutes
 from ocf_data_sampler.config.model import Configuration
+from ocf_data_sampler.datasets.pvnet.types import SourceDict
 from ocf_data_sampler.select.time_periods import (
     find_contiguous_t0_periods,
     find_contiguous_t0_periods_nwp,
     intersection_of_multiple_dataframes_of_periods,
 )
-from ocf_data_sampler.datasets.pvnet.types import SourceDict
 
 
 def find_valid_time_periods(
     datasets_dict: SourceDict,
-    config: Configuration
+    config: Configuration,
 ) -> pd.DataFrame:
     """Find the t0 times where all of the requested input data is available.
 

--- a/src/ocf_data_sampler/datasets/pvnet/valid_t0s.py
+++ b/src/ocf_data_sampler/datasets/pvnet/valid_t0s.py
@@ -10,9 +10,13 @@ from ocf_data_sampler.select.time_periods import (
     find_contiguous_t0_periods_nwp,
     intersection_of_multiple_dataframes_of_periods,
 )
+from ocf_data_sampler.datasets.pvnet.types import SourceDict
 
 
-def find_valid_time_periods(datasets_dict: dict, config: Configuration) -> pd.DataFrame:
+def find_valid_time_periods(
+    datasets_dict: SourceDict,
+    config: Configuration
+) -> pd.DataFrame:
     """Find the t0 times where all of the requested input data is available.
 
     Args:
@@ -23,7 +27,7 @@ def find_valid_time_periods(datasets_dict: dict, config: Configuration) -> pd.Da
         raise ValueError(f"Invalid keys in datasets_dict: {datasets_dict.keys()}")
 
     # Used to store contiguous time periods from each data source
-    contiguous_time_periods: dict[str : pd.DataFrame] = {}
+    contiguous_time_periods: dict[str, pd.DataFrame] = {}
     if "nwp" in datasets_dict:
         for nwp_key, nwp_config in config.input_data.nwp.items():
             da = datasets_dict["nwp"][nwp_key]

--- a/src/ocf_data_sampler/features/diff_channels.py
+++ b/src/ocf_data_sampler/features/diff_channels.py
@@ -1,8 +1,9 @@
 """Takes the diff along the step axis for a given set of channels."""
 
 import numpy as np
-import xarray as xr
+
 from ocf_data_sampler.common.types import TArray
+
 
 def diff_channels(da: TArray, accum_channels: list[str]) -> TArray:
     """Perform in-place diff of the given channels of the DataArray in the steps dimension.

--- a/src/ocf_data_sampler/features/diff_channels.py
+++ b/src/ocf_data_sampler/features/diff_channels.py
@@ -2,9 +2,9 @@
 
 import numpy as np
 import xarray as xr
+from ocf_data_sampler.common.types import TArray
 
-
-def diff_channels(da: xr.DataArray, accum_channels: list[str]) -> xr.DataArray:
+def diff_channels(da: TArray, accum_channels: list[str]) -> TArray:
     """Perform in-place diff of the given channels of the DataArray in the steps dimension.
 
     Args:
@@ -14,7 +14,7 @@ def diff_channels(da: xr.DataArray, accum_channels: list[str]) -> xr.DataArray:
     if da.dims[:2] != ("step", "channel"):
         raise ValueError("This function assumes the first two dimensions are step then channel")
 
-    all_channels = da.channel.values
+    all_channels = da["channel"].values
     accum_channel_inds = [i for i, c in enumerate(all_channels) if c in accum_channels]
 
     # Make a copy of the values to avoid changing the underlying numpy array

--- a/src/ocf_data_sampler/load/generation.py
+++ b/src/ocf_data_sampler/load/generation.py
@@ -45,8 +45,8 @@ def open_generation(zarr_path: str, public: bool = False) -> xr.DataArray:
 
     da = ds.to_dataarray("gen_param").transpose("time_utc", "location_id", "gen_param")
 
-    assert_values_unique_increasing(ds.time_utc.values, "time_utc")
-    assert_values_unique_increasing(ds.location_id.values, "location_id")
+    assert_values_unique_increasing(ds["time_utc"].values, "time_utc")
+    assert_values_unique_increasing(ds["location_id"].values, "location_id")
 
     # Validate data types
     if not np.issubdtype(da.dtype, np.floating):

--- a/src/ocf_data_sampler/load/nwp.py
+++ b/src/ocf_data_sampler/load/nwp.py
@@ -211,7 +211,7 @@ def _canonicalize_regular_grid_layout(
     Expects dims/coords already standardised to: init_time_utc, step, channel,
     plus the given x_coord/y_coord spatial dims.
     """
-    assert_values_unique_increasing(ds.init_time_utc.values, "init_time_utc")
+    assert_values_unique_increasing(ds["init_time_utc"].values, "init_time_utc")
     ds = make_spatial_coords_increasing(ds, x_coord=x_coord, y_coord=y_coord)
     ds = ds.transpose("init_time_utc", "step", "channel", x_coord, y_coord)
 

--- a/src/ocf_data_sampler/load/satellite.py
+++ b/src/ocf_data_sampler/load/satellite.py
@@ -39,7 +39,7 @@ def open_sat_data(zarr_path: str | list[str]) -> xr.DataArray:
     ds = ds.rename(rename_dict)
 
     ds = make_spatial_coords_increasing(ds, x_coord="x_geostationary", y_coord="y_geostationary")
-    assert_values_unique_increasing(ds.time_utc.values, "time_utc")
+    assert_values_unique_increasing(ds["time_utc"].values, "time_utc")
     ds = ds.transpose("time_utc", "channel", "x_geostationary", "y_geostationary")
 
     da = get_xr_data_array_from_xr_dataset(ds)

--- a/src/ocf_data_sampler/select/dropout.py
+++ b/src/ocf_data_sampler/select/dropout.py
@@ -14,7 +14,7 @@ def apply_history_dropout(
     dropout_frac: float | list[float],
     da: xr.DataArray,
 ) -> xr.DataArray:
-    """Apply randomly sampled dropout to the historical part of some sequence data.
+    """Apply in-place random dropout to the historical part of some sequence data.
 
     Dropped out data is replaced with NaNs
 
@@ -55,4 +55,10 @@ def apply_history_dropout(
     if timedelta_choice is None:
         return da
     else:
-        return da.where((da.time_utc <= timedelta_choice + t0) | (da.time_utc> t0))
+        times = da["time_utc"].values
+        keep = (times <= t0 + timedelta_choice) | (times > t0)
+        axis = da.dims.index("time_utc")
+        mask = np.expand_dims(keep, tuple(i for i in range(da.data.ndim) if i != axis))
+        da.data = np.where(mask, da.data, np.nan)
+        return da
+

--- a/src/ocf_data_sampler/select/spatial_slice.py
+++ b/src/ocf_data_sampler/select/spatial_slice.py
@@ -2,15 +2,15 @@
 
 import numpy as np
 
+from ocf_data_sampler.common.types import DataArrayLike, TArray
 from ocf_data_sampler.spatial import Location, find_coord_system
-from ocf_data_sampler.common.types import TArray
 
 
-def _get_pixel_index_location(da: TArray, location: Location) -> tuple[int, int]:
+def _get_pixel_index_location(da: DataArrayLike, location: Location) -> tuple[int, int]:
     """Find pixel index location closest to given Location.
 
     Args:
-        da: The xarray DataArray.
+        da: The DataArray-like object.
         location: The Location object representing the point of interest.
 
     Returns:
@@ -51,7 +51,7 @@ def select_spatial_slice_pixels(
     """Select spatial slice based off pixels from location point of interest.
 
     Args:
-        da: xarray DataArray to slice from
+        da: DataArray-like object to slice from
         location: Location of interest that will be the center of the returned slice
         height_pixels: Height of the slice in pixels
         width_pixels: Width of the slice in pixels
@@ -114,7 +114,7 @@ def select_spatial_slice_pixels_multiple(
     """Select spatial slice which covers all given locations.
 
     Args:
-        da: xarray DataArray to slice from
+        da: DataArray-like object to slice from
         locations: List of locations of interest that will be covered by the returned slice
         height_pixels: Height of the slice in pixels
         width_pixels: Width of the slice in pixels

--- a/src/ocf_data_sampler/select/spatial_slice.py
+++ b/src/ocf_data_sampler/select/spatial_slice.py
@@ -1,12 +1,12 @@
 """Select spatial slices."""
 
 import numpy as np
-import xarray as xr
 
 from ocf_data_sampler.spatial import Location, find_coord_system
+from ocf_data_sampler.common.types import TArray
 
 
-def _get_pixel_index_location(da: xr.DataArray, location: Location) -> tuple[int, int]:
+def _get_pixel_index_location(da: TArray, location: Location) -> tuple[int, int]:
     """Find pixel index location closest to given Location.
 
     Args:
@@ -43,11 +43,11 @@ def _get_pixel_index_location(da: xr.DataArray, location: Location) -> tuple[int
 
 
 def select_spatial_slice_pixels(
-    da: xr.DataArray,
+    da: TArray,
     location: Location,
     width_pixels: int,
     height_pixels: int,
-) -> xr.DataArray:
+) -> TArray:
     """Select spatial slice based off pixels from location point of interest.
 
     Args:
@@ -106,11 +106,11 @@ def select_spatial_slice_pixels(
 
 
 def select_spatial_slice_pixels_multiple(
-    da: xr.DataArray,
+    da: TArray,
     locations: list[Location],
     width_pixels: int,
     height_pixels: int,
-) -> xr.DataArray:
+) -> TArray:
     """Select spatial slice which covers all given locations.
 
     Args:

--- a/src/ocf_data_sampler/select/time_periods.py
+++ b/src/ocf_data_sampler/select/time_periods.py
@@ -7,7 +7,6 @@ from numpy.typing import NDArray
 from ocf_data_sampler.common.indexing import assert_values_unique_increasing
 from ocf_data_sampler.common.time_utils import date_range, datetime_ceil
 
-
 ZERO_TDELTA = np.timedelta64(0, "ns")
 
 

--- a/src/ocf_data_sampler/select/time_periods.py
+++ b/src/ocf_data_sampler/select/time_periods.py
@@ -7,6 +7,7 @@ from numpy.typing import NDArray
 from ocf_data_sampler.common.indexing import assert_values_unique_increasing
 from ocf_data_sampler.common.time_utils import date_range, datetime_ceil
 
+
 ZERO_TDELTA = np.timedelta64(0, "ns")
 
 

--- a/src/ocf_data_sampler/select/time_slice.py
+++ b/src/ocf_data_sampler/select/time_slice.py
@@ -1,19 +1,19 @@
 """Select a time slice from a Dataset or DataArray."""
 
 import numpy as np
-import xarray as xr
 
 from ocf_data_sampler.common.indexing import get_indices_in_sorted_unique
 from ocf_data_sampler.common.time_utils import date_range, datetime_ceil
+from ocf_data_sampler.common.types import TArray
 
 
 def select_time_slice(
-    da: xr.DataArray,
+    da: TArray,
     t0: np.datetime64,
     interval_start: np.timedelta64,
     interval_end: np.timedelta64,
     time_resolution: np.timedelta64,
-) -> xr.DataArray:
+) -> TArray:
     """Select a time slice from a DataArray.
 
     Args:
@@ -25,20 +25,20 @@ def select_time_slice(
     """
     date_range = np.array([t0 + interval_start, t0 + interval_end])
     ceil_date_range = datetime_ceil(date_range, time_resolution)
-    start_ind, end_ind = get_indices_in_sorted_unique(da.time_utc.values, ceil_date_range)
+    start_ind, end_ind = get_indices_in_sorted_unique(da["time_utc"].values, ceil_date_range)
 
     return da.isel(time_utc=slice(start_ind, end_ind+1))
 
 
 def select_time_slice_nwp(
-    da: xr.DataArray,
+    da: TArray,
     t0: np.datetime64,
     interval_start: np.timedelta64,
     interval_end: np.timedelta64,
     time_resolution: np.timedelta64,
     dropout_timedeltas: list[np.timedelta64] | None = None,
     dropout_frac: float | None = 0,
-) -> xr.DataArray:
+) -> TArray:
     """Select a time slice from an NWP DataArray.
 
     Args:
@@ -71,8 +71,8 @@ def select_time_slice_nwp(
     target_times = date_range(start_dt, end_dt, freq=time_resolution)
 
     # Unpack for convenience and so we don't need to unpack multiple times
-    all_init_times = da.init_time_utc.values
-    all_steps = da.step.values
+    all_init_times = da["init_time_utc"].values
+    all_steps = da["step"].values
 
     # Potentially apply NWP dropout
     if consider_dropout and (np.random.uniform() < dropout_frac):

--- a/src/ocf_data_sampler/spatial.py
+++ b/src/ocf_data_sampler/spatial.py
@@ -6,10 +6,14 @@ Supports coordinate systems:
 - Geostationary satellite coordinate systems
 """
 
+from typing import Any, TypeVar
+
 import numpy as np
 import pyproj
-import xarray as xr
+from numpy.typing import NDArray
 from pyresample.area_config import load_area_from_string
+
+from ocf_data_sampler.common.types import DataArrayLike
 
 ALLOWED_COORD_SYSTEMS = {"osgb", "lon_lat", "geostationary"}
 
@@ -20,15 +24,18 @@ OSGB36 = 27700
 # WGS84: World Geodetic System 1984 (longitude/latitude in degrees) - https://epsg.io/4326
 WGS84 = 4326
 
+
+TCoordinateValue = TypeVar("TCoordinateValue", float, NDArray[np.number[Any]])
+
 # Pre-inititiate coordinate Transformer objects
 _osgb_to_lon_lat = pyproj.Transformer.from_crs(crs_from=OSGB36, crs_to=WGS84, always_xy=True)
 _lon_lat_to_osgb = pyproj.Transformer.from_crs(crs_from=WGS84, crs_to=OSGB36, always_xy=True)
 
 
 def osgb_to_lon_lat(
-    x: float | np.ndarray,
-    y: float | np.ndarray,
-) -> tuple[float | np.ndarray, float | np.ndarray]:
+    x: TCoordinateValue,
+    y: TCoordinateValue,
+) -> tuple[TCoordinateValue, TCoordinateValue]:
     """Convert OSGB coordinates to lon-lat.
 
     Args:
@@ -42,9 +49,9 @@ def osgb_to_lon_lat(
 
 
 def lon_lat_to_osgb(
-    x: float | np.ndarray,
-    y: float | np.ndarray,
-) -> tuple[float | np.ndarray, float | np.ndarray]:
+    x: TCoordinateValue,
+    y: TCoordinateValue,
+) -> tuple[TCoordinateValue, TCoordinateValue]:
     """Convert lon-lat coordinates to OSGB.
 
     Args:
@@ -85,10 +92,10 @@ def _get_geostationary_coord_transform(
 
 
 def lon_lat_to_geostationary_area_coords(
-    longitude: float | np.ndarray,
-    latitude: float | np.ndarray,
+    longitude: TCoordinateValue,
+    latitude: TCoordinateValue,
     area_string: str,
-) -> tuple[float | np.ndarray, float | np.ndarray]:
+) -> tuple[TCoordinateValue, TCoordinateValue]:
     """Convert from lon-lat to geostationary coords.
 
     Args:
@@ -104,10 +111,10 @@ def lon_lat_to_geostationary_area_coords(
 
 
 def osgb_to_geostationary_area_coords(
-    x: float | np.ndarray,
-    y: float | np.ndarray,
+    x: TCoordinateValue,
+    y: TCoordinateValue,
     area_string: str,
-) -> tuple[float | np.ndarray, float | np.ndarray]:
+) -> tuple[TCoordinateValue, TCoordinateValue]:
     """Convert from OSGB to geostationary coords.
 
     Args:
@@ -122,8 +129,8 @@ def osgb_to_geostationary_area_coords(
     return coord_transformer.transform(xx=x, yy=y)
 
 
-def find_coord_system(da: xr.DataArray) -> tuple[str, str, str]:
-    """Searches the Xarray object to determine the spatial coordinate system.
+def find_coord_system(da: DataArrayLike) -> tuple[str, str, str]:
+    """Searches the DataArray-like object to determine the spatial coordinate system.
 
     Args:
         da: Dataset with spatial coords
@@ -136,10 +143,10 @@ def find_coord_system(da: xr.DataArray) -> tuple[str, str, str]:
     # included as non-dimensional coords
     dimensional_coords = set(da.dims)
 
-    coord_systems = {
-        "lon_lat": ["longitude", "latitude"],
-        "geostationary": ["x_geostationary", "y_geostationary"],
-        "osgb": ["x_osgb", "y_osgb"],
+    coord_systems: dict[str, tuple[str, str]] = {
+        "lon_lat": ("longitude", "latitude"),
+        "geostationary": ("x_geostationary", "y_geostationary"),
+        "osgb": ("x_osgb", "y_osgb"),
     }
 
     coords_systems_found = []
@@ -163,12 +170,12 @@ def find_coord_system(da: xr.DataArray) -> tuple[str, str, str]:
 
 
 def convert_coordinates(
-    x: float | np.ndarray,
-    y: float | np.ndarray,
+    x: TCoordinateValue,
+    y: TCoordinateValue,
     from_coords: str,
     target_coords: str,
     area_string: str | None = None,
-) -> tuple[float | np.ndarray, float | np.ndarray]:
+) -> tuple[TCoordinateValue, TCoordinateValue]:
     """Convert x and y coordinates from one coordinate system to another.
 
     Args:
@@ -185,15 +192,22 @@ def convert_coordinates(
     if from_coords==target_coords:
         return x, y
 
-    if "geostationary" in (from_coords, target_coords) and area_string is None:
-        raise ValueError("If using geostationary coords the `area_string` must be provided")
-
     match (from_coords, target_coords):
 
         case ("osgb", "geostationary"):
+            if area_string is None:
+                raise ValueError(
+                    "The `area_string` must be provided when converting to geostationary "
+                    "coordinates",
+                )
             x, y = osgb_to_geostationary_area_coords(x, y, area_string)
 
         case ("lon_lat", "geostationary"):
+            if area_string is None:
+                raise ValueError(
+                    "The `area_string` must be provided when converting to geostationary "
+                    "coordinates",
+                )
             x, y = lon_lat_to_geostationary_area_coords(x, y, area_string)
 
         case ("osgb", "lon_lat"):

--- a/tests/features/test_diff_channels.py
+++ b/tests/features/test_diff_channels.py
@@ -5,12 +5,12 @@ def test_diff_channels(ds_nwp_ukv_time_sliced):
     # Construct copy as function edits inputs in-place
     # Assert more than one channel in fixture
     da = ds_nwp_ukv_time_sliced.copy(deep=True)
-    channels = list(da.channel.values)
+    channels = list(da["channel"].values)
     assert len(channels) > 1
 
     # Assert diff function reduces the steps by one
     da_diffed = diff_channels(da, accum_channels=channels[:1])
-    assert (da_diffed.step.values == ds_nwp_ukv_time_sliced.step.values[:-1]).all()
+    assert (da_diffed["step"].values == ds_nwp_ukv_time_sliced["step"].values[:-1]).all()
 
     # Check these channels have not been changed
     expected_unchanged = ds_nwp_ukv_time_sliced.isel(channel=slice(1, None), step=slice(None, -1))

--- a/tests/select/test_dropout.py
+++ b/tests/select/test_dropout.py
@@ -7,7 +7,11 @@ from ocf_data_sampler.select.dropout import apply_history_dropout
 
 
 def test_apply_history_dropout_multiple_timedeltas(da_sample):
-    t0 = da_sample.time_utc.values[-1]
+
+    # Dropout edits the input in-place, so make a copy to avoid affecting other tests
+    da_sample = da_sample.copy(deep=True)
+
+    t0 = da_sample["time_utc"].values[-1]
 
     da_sample_dropout = apply_history_dropout(
         t0,
@@ -27,7 +31,11 @@ def test_apply_history_dropout_multiple_timedeltas(da_sample):
 
 
 def test_apply_history_dropout_none(da_sample):
-    t0 = da_sample.time_utc.values[-1]
+
+    # Dropout edits the input in-place, so make a copy to avoid affecting other tests
+    da_sample = da_sample.copy(deep=True)
+
+    t0 = da_sample["time_utc"].values[-1]
 
     da_sample_dropout = apply_history_dropout(
         t0,
@@ -47,7 +55,11 @@ def test_apply_history_dropout_none(da_sample):
 
 
 def test_apply_history_dropout_list(da_sample):
-    t0 = da_sample.time_utc.values[-1]
+
+    # Dropout edits the input in-place, so make a copy to avoid affecting other tests
+    da_sample = da_sample.copy(deep=True)
+
+    t0 = da_sample["time_utc"].values[-1]
 
     da_sample_dropout = apply_history_dropout(
         t0,
@@ -68,6 +80,10 @@ def test_apply_history_dropout_list(da_sample):
 
 @pytest.mark.parametrize("t0_str", ["12:30", "13:00", "13:30"])
 def test_apply_history_dropout(da_sample, t0_str):
+
+    # Dropout edits the input in-place, so make a copy to avoid affecting other tests
+    da_sample = da_sample.copy(deep=True)
+
     t0_time = pd.Timestamp(f"2024-01-01 {t0_str}")
     dropout_time = t0_time + minutes(-30)
 

--- a/tests/select/test_spatial_slice.py
+++ b/tests/select/test_spatial_slice.py
@@ -24,8 +24,8 @@ def test_select_spatial_slice_pixels(da):
     )
 
     assert isinstance(da_sliced, xr.DataArray)
-    assert (da_sliced.x_osgb.values == np.arange(-95, -85)).all()
-    assert (da_sliced.y_osgb.values == np.arange(-85, -75)).all()
+    assert (da_sliced["x_osgb"].values == np.arange(-95, -85)).all()
+    assert (da_sliced["y_osgb"].values == np.arange(-85, -75)).all()
     assert not da_sliced.isnull().any()
 
     # Select window where the edge of the window lies right on the edge of the data
@@ -37,8 +37,8 @@ def test_select_spatial_slice_pixels(da):
     )
 
     assert isinstance(da_sliced, xr.DataArray)
-    assert (da_sliced.x_osgb.values == np.arange(-100, -80)).all()
-    assert (da_sliced.y_osgb.values == np.arange(-90, -70)).all()
+    assert (da_sliced["x_osgb"].values == np.arange(-100, -80)).all()
+    assert (da_sliced["y_osgb"].values == np.arange(-90, -70)).all()
     assert not da_sliced.isnull().any()
 
 

--- a/tests/select/test_time_slice.py
+++ b/tests/select/test_time_slice.py
@@ -84,9 +84,9 @@ def test_select_time_slice_nwp_basic(da_nwp_like, t0_str):
     assert (valid_times == expected_target_times).all()
 
     # Check the init-time is the first init time before the first target time
-    init_times = da_nwp_like.init_time_utc.values
+    init_times = da_nwp_like["init_time_utc"].values
     expected_init_time = init_times[init_times<=expected_target_times[0]][-1]
-    assert (expected_init_time == da_slice.init_time_utc.values)
+    assert (expected_init_time == da_slice["init_time_utc"].values)
 
 
 @pytest.mark.parametrize("dropout_hours", [1, 2, 3, 5])
@@ -111,12 +111,12 @@ def test_select_time_slice_nwp_with_dropout(da_nwp_like, dropout_hours):
 
     # Check the target-times are as expected
     expected_target_times = date_range(t0 + interval_start, t0 + interval_end, freq=freq)
-    valid_times = da_slice.init_time_utc + da_slice.step
+    valid_times = da_slice["init_time_utc"] + da_slice["step"]
     assert (valid_times == expected_target_times).all()
 
     # Check the init-time is the first init time before the first target time whilst considering the
     # delay
     t0_delayed = min(t0 + dropout_timedelta, expected_target_times[0])
-    init_times = da_nwp_like.init_time_utc.values
+    init_times = da_nwp_like["init_time_utc"].values
     expected_init_time = init_times[init_times<=t0_delayed][-1]
-    assert (expected_init_time == da_slice.init_time_utc.values)
+    assert (expected_init_time == da_slice["init_time_utc"].values)


### PR DESCRIPTION
# Pull Request

## Description

This PR tightens up our support for the `LightDataArray` class alongside `xarray.DataArray`

- We add a `DataArrayLike` protocol which defines the methods and properties which any data structure needs to be used in the rest of the codebase. This should allow us to plug in other data classes in the future like the rumoured `zax`
- We remove the use of `da.time_utc` etc in favour of `da["time_utc"]` to reduce the scope for any `DataArrayLike` objects
- We update the `apply_history_dropout()` to remove the requirement for a `.where()` method, which didn't exist on  the `LightDataArray` class. This reduces the scope of `DataArrayLike`. We also change this to an in-place operation for efficiency
- Turn on type checking for some of the low level models -> `common`, `spatial.py`. I have to admit that I have some reservations about static type checking being a useful tool in this repo. It may be more effort than it's worth and risks us overcomplicating our code to appease `mypy`. That's why I've kept the scope so small for type-checking

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
