### PR TITLE
Fix LightDataArray.isel indexing and generation validation

### DIFF
--- a/src/ocf_data_sampler/common/lightarray.py
+++ b/src/ocf_data_sampler/common/lightarray.py
@@ -1,6 +1,6 @@
 """A lightweight DataArray-like class."""
 
-from typing import Any, TypedDict
+from typing import Any, TypedDict, overload
 
 import numpy as np
 import tensorstore as ts
@@ -134,9 +134,23 @@ def _normalise_index_origin(data: np.ndarray | ts.TensorStore) -> np.ndarray | t
     return np.asarray(data)
 
 
+@overload
+def _apply_axis_indexers(
+    data: np.ndarray,
+    axis_indexers: tuple[Indexer, ...],
+) -> np.ndarray: ...
+
+
+@overload
+def _apply_axis_indexers(
+    data: ts.TensorStore,
+    axis_indexers: tuple[Indexer, ...],
+) -> ts.TensorStore: ...
+
+
 def _apply_axis_indexers(
     data: np.ndarray | ts.TensorStore,
-    axis_indexers: tuple[Indexer, ...]
+    axis_indexers: tuple[Indexer, ...],
 ) -> np.ndarray | ts.TensorStore:
 
     if len(axis_indexers) != data.ndim:

--- a/src/ocf_data_sampler/common/lightarray.py
+++ b/src/ocf_data_sampler/common/lightarray.py
@@ -297,6 +297,10 @@ class LightDataArray:
             indexers: A dict with keys matching dimensions and values given by integers, slice
                 objects or arrays. `indexer` can be an integer, slice or array-like.
             **indexers_kwargs: The keyword arguments form of indexers.
+
+        Returns:
+            A new LightDataArray. Attributes are copied, while coordinate arrays may be views of
+            the original coordinate arrays rather than independent copies.
         """
         if indexers is not None:
             indexers_kwargs.update(indexers)

--- a/src/ocf_data_sampler/common/lightarray.py
+++ b/src/ocf_data_sampler/common/lightarray.py
@@ -3,9 +3,8 @@
 from typing import Any, TypedDict
 
 import numpy as np
+import tensorstore as ts
 import xarray as xr
-from tensorstore import Future as TensorStoreFuture
-from tensorstore import TensorStore
 from xarray_tensorstore import _TensorStoreAdapter
 
 from ocf_data_sampler.common.types import Indexer
@@ -14,41 +13,221 @@ from ocf_data_sampler.common.types import Indexer
 class LightDataArrayState(TypedDict):
     """Serialized state of a LightDataArray."""
 
-    _data: np.ndarray | TensorStore
+    _data: np.ndarray | ts.TensorStore
     dims: tuple[str, ...]
-    coords: dict[str, np.ndarray]
+    coords: dict[str, tuple[tuple[str, ...], np.ndarray]]
     attrs: dict[Any, Any]
-    coord_dims: dict[str, tuple[str, ...]]
+
+
+def _validate_coords(
+    data: np.ndarray | ts.TensorStore,
+    dims: tuple[str, ...],
+    coords: dict[str, tuple[tuple[str, ...], np.ndarray]]
+) -> None:
+    """Helper to validate the coordinates dictionary."""
+    for coord_name, (coord_dims, coord_values) in coords.items():
+
+        # Check types in coords
+        if not isinstance(coord_name, str):
+            raise TypeError(f"Coordinate name must be a string. Got {type(coord_name)}.")
+        if not isinstance(coord_dims, tuple) or not all(isinstance(dim, str) for dim in coord_dims):
+            raise TypeError(
+                f"Coordinate dimensions must be a tuple of strings. Got {coord_dims}.",
+            )
+        if not isinstance(coord_values, np.ndarray):
+            raise TypeError(
+                f"Coordinate values must be a numpy array. Got {type(coord_values)}.",
+            )
+
+        # Check that the number of dimensions in the coordinate values matches the number of
+        # dimensions
+        if not len(coord_dims) == coord_values.ndim:
+            raise ValueError(
+                f"Number of dimensions for coordinate '{coord_name}' ({len(coord_dims)}) must "
+                f"match the number of dimensions in its values ({coord_values.ndim}).",
+            )
+
+        # We allow non-dimensional coordinates (i.e. coords not in dims) to be multidimensional, so
+        # check that all the dimensions in coord_dims are present in coords
+        for dim in coord_dims:
+            if dim not in coords:
+                raise ValueError(
+                    f"Dimension '{dim}' for coordinate '{coord_name}' is not present in the "
+                     "coordinates dictionary.",
+                )
+
+    for dim in dims:
+        # Check types
+        if not isinstance(dim, str):
+            raise TypeError(f"Dimension names must be strings. Got {type(dim)}.")
+        # Check that all dimensions are present in coords
+        if dim not in coords:
+            raise ValueError(f"Dimension '{dim}' is not present in the coordinates dictionary.")
+
+    # Check that the number of dimensions in dims matches the number of dimensions in the data
+    if not len(dims) == data.ndim:
+        raise ValueError(
+            f"Number of dimensions ({len(dims)}) must match the number of dimensions "
+            f"({data.ndim}) in the data.",
+        )
+
+    for i, dim in enumerate(dims):
+        if data.shape[i] != coords[dim][1].shape[0]:
+            raise ValueError(
+                f"Dimension '{dim}' has size {data.shape[i]} in the data but size "
+                f"{coords[dim][1].shape[0]} in the coordinates.",
+            )
+
+
+def _sanitise_indexer(dim: str, dim_size: int, indexer: Indexer) -> Indexer:
+    """Normalise an indexer so dimension-collapse logic and indexing agree on its semantics."""
+    if isinstance(indexer, bool | np.bool_):
+        raise TypeError(
+            f"Found scalar boolean indexer on dimension '{dim}'. Scalar boolean indexers are not "
+            "supported."
+        )
+
+    # Pass the expected types through unchanged
+    if isinstance(indexer, int | np.integer | slice):
+        return indexer
+
+    # Convert array-likes (e.g. list, tuple) to numpy arrays
+    indexer = np.asarray(indexer)
+
+    # Convert 0-d integer arrays to plain ints
+    if indexer.ndim == 0:
+        if not np.issubdtype(indexer.dtype, np.integer):
+            raise TypeError(
+                f"0-d indexer for dimension '{dim}' must be of integer type. "
+                f"Got dtype {indexer.dtype}.",
+            )
+        return int(indexer)
+
+    # Check that the indexer is at most 1-dimensional
+    if indexer.ndim > 1:
+        raise ValueError(
+            f"Indexer for dimension '{dim}' must be at most 1-dimensional. "
+            f"Got {indexer.ndim} dimensions.",
+        )
+
+    if np.issubdtype(indexer.dtype, np.bool_):
+        if len(indexer) != dim_size:
+            raise IndexError(
+                f"Boolean indexer for dimension '{dim}' has length {len(indexer)}, but the "
+                f"dimension has length {dim_size}.",
+            )
+        return indexer
+
+    if not np.issubdtype(indexer.dtype, np.integer):
+        raise TypeError(
+            f"Indexer for dimension '{dim}' must have an integer or boolean dtype. "
+            f"Got dtype {indexer.dtype}.",
+        )
+
+    return indexer
+
+
+def _normalise_index_origin(data: np.ndarray | ts.TensorStore) -> np.ndarray | ts.TensorStore:
+    """Translate TensorStore domains to zero so subsequent indexing remains positional."""
+    if isinstance(data, ts.TensorStore):
+        return data[ts.d[:].translate_to[0]]
+    return np.asarray(data)
+
+
+def _apply_axis_indexers(
+    data: np.ndarray | ts.TensorStore,
+    axis_indexers: tuple[Indexer, ...]
+) -> np.ndarray | ts.TensorStore:
+
+    if len(axis_indexers) != data.ndim:
+        raise ValueError(
+            f"Number of indexers ({len(axis_indexers)}) must match the number of dimensions "
+            f"({data.ndim}) in the data.",
+        )
+
+    # If all indexers are integers or slices, we can apply them directly to the data in one step.
+    # This is the fastest path and is the most common case, so we check for it first.
+    if all(isinstance(indexer, int | np.integer | slice) for indexer in axis_indexers):
+        return _normalise_index_origin(data[axis_indexers])
+
+    # Apply basic indexers together, then array indexers one axis at a time to preserve xarray's
+    # orthogonal indexing semantics without slowing down the common int-and-slice path.
+    basic_indexers = tuple(
+        indexer if isinstance(indexer, int | np.integer | slice) else slice(None)
+        for indexer in axis_indexers
+    )
+    sliced_data = _normalise_index_origin(data[basic_indexers])
+
+    current_axis = 0
+    for indexer in axis_indexers:
+
+        # Slices are already applied in the basic_indexers step, so we skip them here and
+        # increment the current_axis counter to keep track of which axis we're on in the sliced data
+        if isinstance(indexer, slice):
+            current_axis += 1
+            continue
+
+        # Dimensions that have been reduced to points do not have an axis in the sliced data, so
+        # we don't increment current_axis for these dimensions
+        elif isinstance(indexer, int | np.integer):
+            continue
+
+        elif isinstance(indexer, np.ndarray | list | tuple):
+            axis_indexer = tuple(
+                indexer if i == current_axis else slice(None) for i in range(current_axis + 1)
+            )
+            sliced_data = _normalise_index_origin(sliced_data[axis_indexer])
+            current_axis += 1
+
+        else:
+            raise TypeError(
+                f"Unsupported indexer type: {type(indexer)}. Must be int, slice, or array-like.",
+            )
+
+    return sliced_data
+
 
 
 class LightDataArray:
     """A lightweight DataArray-like class."""
 
-    __slots__ = ["_data", "attrs", "coord_dims", "coords", "dims", "future"]
+    __slots__ = ["_data", "_future", "attrs", "coords", "dims"]
 
     def __init__(
         self,
-        data: np.ndarray | TensorStore,
+        data: np.ndarray | ts.TensorStore,
+        coords: dict[str, tuple[tuple[str, ...], np.ndarray]],
         dims: tuple[str, ...],
-        coords: dict[str, np.ndarray],
-        coord_dims: dict[str, tuple[str, ...]],
         attrs: dict[Any, Any] | None = None,
+        skip_validation: bool = False,
     ) -> None:
-        """A lightweight DataArray-like class."""
+        """A lightweight DataArray-like class.
+
+        Args:
+            data: Values for this array
+            coords: Coordinates (tick labels) to use for indexing along each dimension. Must be of
+                the form {coord name: (tuple of dimension names, array-like)}.
+            dims: The dimension names corresponding to the axes of the data
+            attrs: Attributes to assign to the new instance
+            skip_validation: Skip validation of the coords against the data and dims. Intended
+                for internal use where inputs are constructed to be consistent.
+        """
+        if not skip_validation:
+            _validate_coords(data, dims, coords)
+
         self._data = data
-        self.dims = dims
         self.coords = coords
-        self.coord_dims = coord_dims
+        self.dims = dims
         self.attrs = attrs or {}
-        self.future: TensorStoreFuture[Any] | None = None
+        self._future: ts.Future[Any] | None = None
 
     @property
-    def data(self) -> np.ndarray | TensorStore:
+    def data(self) -> np.ndarray | ts.TensorStore:
         """Return the backing array."""
         return self._data
 
     @data.setter
-    def data(self, value: np.ndarray | TensorStore) -> None:
+    def data(self, value: np.ndarray | ts.TensorStore) -> None:
         """Replace the backing array without changing dimensions."""
         if value.shape != self.shape:
             raise ValueError(
@@ -57,13 +236,13 @@ class LightDataArray:
             )
 
         self._data = value
-        self.future = None
+        self._future = None
 
     @classmethod
     def from_xarray(cls, da: xr.DataArray) -> "LightDataArray":
         """Create a LightDataArray from an Xarray DataArray."""
         # Get raw data handle which can be a numpy array or TensorStore
-        data: TensorStore | np.ndarray
+        data: ts.TensorStore | np.ndarray
         if isinstance(da.variable._data, _TensorStoreAdapter):
             data = da.variable._data.array
         elif isinstance(da.variable._data, np.ndarray):
@@ -71,51 +250,26 @@ class LightDataArray:
         else:
             raise ValueError(f"Data backend of type {type(da.variable._data)} not supported.")
 
-        coord_values: dict[str, np.ndarray] = {}
-        coord_dims: dict[str, tuple[str, ...]] = {}
-
-        for k, v in da.coords.items():
-            if v.ndim <= 1:
-                coord_name = str(k)
-                coord_values[coord_name] = v.values
-                coord_dims[coord_name] = tuple(str(dim) for dim in v.dims)
-            else:
-                raise ValueError(
-                    "Coordinates with more than 1 dimension not supported. "
-                    f"Found coord '{k}' with shape {v.shape}.",
-                )
-
         dims = tuple(str(d) for d in da.dims)
+        coords = {
+            str(k): (tuple(str(dim) for dim in v.dims), v.values) for k, v in da.coords.items()
+        }
 
         return cls(
             data=data,
             dims=dims,
-            coords=coord_values,
-            coord_dims=coord_dims,
+            coords=coords,
             attrs=da.attrs,
+            skip_validation=True,
         )
 
     def to_xarray(self) -> xr.DataArray:
-        """Convert to an Xarray DataArray.
-
-        Note this loads the data eagerly.
-        """
-        coords_dict: dict[str, Any] = {}
-        for c, v in self.coords.items():
-            cdims = self.coord_dims.get(c, ())
-
-            # If it's a 1D array and the dimension is still in our dims list
-            if np.ndim(v) == 1 and cdims[0] in self.dims:
-                coords_dict[c] = (cdims, v)
-            else:
-                # It's a scalar or a non-indexed coordinate
-                coords_dict[c] = v
-
+        """Convert to an Xarray DataArray."""
         return xr.DataArray(
-            data=self.values,
+            data=self.data,
             dims=self.dims,
-            coords=coords_dict,
-            attrs=self.attrs,
+            coords=self.coords,
+            attrs=dict(self.attrs),
         )
 
     def isel(
@@ -133,53 +287,57 @@ class LightDataArray:
         if indexers is not None:
             indexers_kwargs.update(indexers)
 
-        axis_indexers: list[Indexer] = [slice(None)] * len(self.dims)
-        new_coords = self.coords.copy()
-        dims_to_remove: list[str] = []
-
-        for dim, indexer in indexers_kwargs.items():
+        # Validate that all indexers correspond to valid dimensions
+        for dim in indexers_kwargs:
             if dim not in self.dims:
                 raise KeyError(
                     f"'{dim}' is not a valid dimension or coordinate for data with dimensions"
                     f"{self.dims}",
                 )
 
-            axis_indexers[self.dims.index(dim)] = indexer
+        # Normalise indexers to simplify the logic for applying them to the data and coordinates
+        indexers_kwargs = {
+            dim: _sanitise_indexer(dim, self.shape[self.dims.index(dim)], indexer)
+            for dim, indexer in indexers_kwargs.items()
+        }
 
-            # Slice the coords which depend on this dimension
-            for c_name, c_dim_name in self.coord_dims.items():
-                if c_dim_name == (dim,):
-                    new_coords[c_name] = new_coords[c_name][indexer]
+        # Slice the data
+        axis_indexers = tuple(indexers_kwargs.get(dim, slice(None)) for dim in self.dims)
+        sliced_data = _apply_axis_indexers(self.data, axis_indexers)
 
-            # Check if this dimension is being collapsed (e.g. an integer index like .isel(time=0))
-            if isinstance(indexer, int | np.integer):
-                dims_to_remove.append(dim)
+        # Remove dimensions that have been reduced to single points (i.e., indexed by an integer)
+        new_dims = tuple(
+            dim for dim in self.dims if not isinstance(indexers_kwargs.get(dim), int | np.integer)
+        )
 
-        # Slice the underlying dta
-        sliced_data = self.data[tuple(axis_indexers)]
-
-        # Remove dims that have been reduced to points
-        remaining_dims = tuple(d for d in self.dims if d not in dims_to_remove)
-
-        # Remove dims from coords that have been reduced to points
-        new_coord_dims = self.coord_dims.copy()
-        for dim in dims_to_remove:
-            for c_name, c_dim_name in self.coord_dims.items():
-                if c_dim_name == (dim,):
-                    new_coord_dims[c_name] = ()
+        # Slice the coordinate values
+        indexed_dims = indexers_kwargs.keys()
+        new_coords = self.coords.copy()
+        for coord_name, (coord_dims, coord_values) in new_coords.items():
+            # If the coordinate is not indexed along any of its dimensions, copy it as is, else
+            # slice the coordinate values along the indexed dimensions
+            if indexed_dims.isdisjoint(coord_dims):
+                new_coords[coord_name] = (coord_dims, coord_values)
+            else:
+                coord_axis_indexers = tuple(
+                    indexers_kwargs.get(dim, slice(None)) for dim in coord_dims
+                )
+                sliced_coord_values = _apply_axis_indexers(coord_values, coord_axis_indexers)
+                new_coord_dims = tuple(dim for dim in coord_dims if dim in new_dims)
+                new_coords[coord_name] = (new_coord_dims, sliced_coord_values)
 
         return LightDataArray(
             data=sliced_data,
-            dims=remaining_dims,
+            dims=new_dims,
             coords=new_coords,
-            coord_dims=new_coord_dims,
-            attrs=self.attrs,
+            attrs=dict(self.attrs),
+            skip_validation=True,
         )
 
     def read(self) -> None:
         """Trigger reading of the data if it's a lazy handle."""
-        if isinstance(self.data, TensorStore):
-            self.future = self.data.read()
+        if isinstance(self.data, ts.TensorStore):
+            self._future = self.data.read()
 
     def load(self) -> "LightDataArray":
         """Load data in-place and return self."""
@@ -191,22 +349,23 @@ class LightDataArray:
         """Return the data as a NumPy array, loading it if necessary."""
         data = self._data
 
-        if not isinstance(data, TensorStore):
+        if not isinstance(data, ts.TensorStore):
             return np.asarray(data)
 
-        if self.future is None:
+        if self._future is None:
             return np.asarray(data.read().result())
 
-        return np.asarray(self.future.result())
+        return np.asarray(self._future.result())
 
     def __getitem__(self, key: str) -> "LightDataArray":
         """Allow access to coordinates via indexing syntax, e.g., da['time']."""
         if key in self.coords:
+            coord_dims, coord_values = self.coords[key]
             return LightDataArray(
-                data=self.coords[key],
-                dims=self.coord_dims[key],
-                coords={key: self.coords[key]},
-                coord_dims={key: self.coord_dims[key]},
+                data=coord_values,
+                dims=coord_dims,
+                coords={key: (coord_dims, coord_values)},
+                skip_validation=True,
             )
         raise KeyError(f"Coordinate '{key}' not found.")
 
@@ -217,7 +376,6 @@ class LightDataArray:
             "dims": self.dims,
             "coords": self.coords,
             "attrs": self.attrs,
-            "coord_dims": self.coord_dims,
         }
 
     def __setstate__(self, state: LightDataArrayState) -> None:
@@ -226,9 +384,8 @@ class LightDataArray:
         self.dims = state["dims"]
         self.coords = state["coords"]
         self.attrs = state["attrs"]
-        self.coord_dims = state["coord_dims"]
         # Restore the un-picklable attribute to a default state
-        self.future = None
+        self._future = None
 
     @property
     def shape(self) -> tuple[int, ...]:

--- a/src/ocf_data_sampler/common/types.py
+++ b/src/ocf_data_sampler/common/types.py
@@ -15,7 +15,14 @@ import numpy as np
 from numpy.typing import NDArray
 
 # Types accepted as a single-dimension indexer in `.isel()` method below.
-Indexer: TypeAlias = int | slice | Sequence[int] | NDArray[np.integer]
+Indexer: TypeAlias = (
+    int
+    | slice
+    | Sequence[int]
+    | Sequence[bool]
+    | NDArray[np.integer]
+    | NDArray[np.bool_]
+)
 
 
 class DataArrayLike(Protocol):

--- a/src/ocf_data_sampler/datasets/pvnet/sample.py
+++ b/src/ocf_data_sampler/datasets/pvnet/sample.py
@@ -33,8 +33,8 @@ def convert_to_numpy_sample(
         da = datasets_dict["generation"]
 
         # Get the position index of the generation and capacities
-        gen_idx = np.argmax(da["gen_param"].values == "generation_mw")
-        cap_idx = np.argmax(da["gen_param"].values == "capacity_mwp")
+        gen_idx = list(da["gen_param"].values).index("generation_mw")
+        cap_idx = list(da["gen_param"].values).index("capacity_mwp")
 
         generation_values = da.isel(gen_param=gen_idx).values
         capacity_value = da.isel(gen_param=cap_idx).values[0]

--- a/src/ocf_data_sampler/load/generation.py
+++ b/src/ocf_data_sampler/load/generation.py
@@ -43,6 +43,12 @@ def open_generation(zarr_path: str, public: bool = False) -> xr.DataArray:
         backend_kwargs=backend_kwargs,
     )
 
+    if set(ds.data_vars) != {"generation_mw", "capacity_mwp"}:
+        raise ValueError(
+            f"Generation data should have variables 'generation_mw' and 'capacity_mwp', "
+            f"but found {set(ds.data_vars)} instead."
+        )
+
     da = ds.to_dataarray("gen_param").transpose("time_utc", "location_id", "gen_param")
 
     assert_values_unique_increasing(ds["time_utc"].values, "time_utc")

--- a/tests/common/test_lightarray.py
+++ b/tests/common/test_lightarray.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import tensorstore as ts
 import xarray as xr
 
 from ocf_data_sampler.common.lightarray import LightDataArray
@@ -49,6 +50,7 @@ def test_isel(xr_gen, xr_ukv, xr_sat):
         (fr_gen, xr_gen, {"location_id": [0]}),
         (fr_gen, xr_gen, {"time_utc": np.array([3,5,7])}),
         (fr_sat, xr_sat, {"time_utc": np.array([5,3,7])}),
+        (fr_gen, xr_gen, {"gen_param": np.array([True, False])}),
     ]
     for fda, xda, indexer in index_tasks_1D:
         sliced_fda = fda.isel(**indexer)
@@ -64,3 +66,54 @@ def test_isel(xr_gen, xr_ukv, xr_sat):
         sliced_fda = fda.isel(**indexer)
         sliced_xda = xda.isel(**indexer)
         assert sliced_fda.to_xarray().equals(sliced_xda)
+
+
+@pytest.mark.parametrize(
+    "indexers",
+    [
+        {"a": [0, 1], "b": [0, 2]},
+        {"a": 0, "c": [0, 2]},
+        {"a": 1, "b": slice(1, None), "c": [0, 2], "d": 3},
+        {"a": [True, False], "b": np.array([False, True, True])},
+        {"a": np.array([False, True]), "c": 2, "d": [True, False, True, False, True]},
+    ],
+)
+def test_isel_conforms_to_xarray(indexers):
+    """Test that multiple indexers preserve xarray's dimension order and values."""
+    dims = ("a", "b", "c", "d")
+    shape = (2, 3, 4, 5)
+    xda = xr.DataArray(
+        np.arange(np.prod(shape)).reshape(shape),
+        dims=dims,
+        coords={dim: np.arange(size) for dim, size in zip(dims, shape, strict=True)},
+    )
+    fda = LightDataArray.from_xarray(xda)
+
+    sliced_fda = fda.isel(**indexers)
+    sliced_xda = xda.isel(**indexers)
+
+    assert sliced_fda.to_xarray().equals(sliced_xda)
+
+
+def test_isel_rejects_boolean_mask_with_wrong_length():
+    """Test that a boolean mask must match the length of its indexed dimension."""
+    xda = xr.DataArray(np.arange(6).reshape(2, 3), dims=("a", "b"))
+    fda = LightDataArray.from_xarray(xda)
+
+    with pytest.raises(IndexError, match="dimension has length 2"):
+        fda.isel(a=[True])
+
+
+def test_isel_tensorstore_slices_are_relative_to_current_array():
+    """Test that repeated TensorStore slicing uses NumPy-style relative indices."""
+    xda = xr.DataArray(np.arange(20), dims=("x",), coords={"x": np.arange(20)})
+    fda = LightDataArray(
+        data=ts.array(xda.values),
+        dims=("x",),
+        coords={"x": (("x",), xda["x"].values)},
+    )
+
+    sliced_fda = fda.isel(x=slice(10, 20)).isel(x=slice(0, 3))
+    sliced_xda = xda.isel(x=slice(10, 20)).isel(x=slice(0, 3))
+
+    assert sliced_fda.to_xarray().equals(sliced_xda)


### PR DESCRIPTION
# Pull Request

## Description


This PR fixes some of the edge cases in the `LightDataArray`'s `.isel()` method. We have not encountered any of these edge cases in our code yet, but this guards us more into the future.


In this PR
- There were a few latent bugs for when we used array-indices eg `ds.sel(time=[0,1,2])`. For example, using multiple arrays indexes on a 2D array `x` like `x[index_arrays_1, index_arrays_2]` returns a 1D array instead of a 2D array. This PR fixes these.
- We preserve the correct dimension order when integer, slice, and array indexers are used across non-adjacent dimensions. Numpy will transpose the array during slicing with some combinations of these, which would misallign our data and coordinates.
- We add support for using an array of boolean masks in `isel()`.
- We normalize TensorStore index origins after slicing so subsequent `isel()` calls continue to use relative positional indices. There was a latent bug if we did `da.isel(dim=slice(10, 20)).isel(dim=slice(0, 1))` which would cause an error using the tensorstore backend
- We add tests covering the above edge-cases to avoid regression
- We tighten indexer validation so unsupported dtypes and multidimensional index arrays fail with clear errors.
- We clean up the internals of `LightDataArray` to only have one data-structure for the coordinates. This also lets us create a `LightDataArray using a style more similar to xarray`. E.g. like the familiar form
   ```
   da = xr.DataArray(
      data=temperature,
      dims=["x", "y", "time"],
      coords=dict(
          lon=(["x", "y"], lon),
          lat=(["x", "y"], lat),
          time=(("time), time),
          reference_time=("reference_time", reference_time),
      ),
      attrs=dict(
          description="Ambient temperature.",
          units="degC",
      ),
  )
  ```
- We tighten up the validation on the generation data to make sure the expected generation and capacity variables exist in the data. We also use safer slicing for these variables for the case they are missing.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
