### PR TITLE
Refactor NWP load module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,3 +141,9 @@ line-ending = "auto"
 docstring-code-format = true
 docstring-code-line-length = 100
 
+
+# --- TESTING CONFIGURATION --- #
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+

--- a/src/ocf_data_sampler/common/xr_tensorstore.py
+++ b/src/ocf_data_sampler/common/xr_tensorstore.py
@@ -15,9 +15,10 @@ References:
 """
 
 import logging
-import os.path
+import os
 import re
-from typing import Any, cast
+from glob import glob, has_magic
+from typing import Any, TypeAlias, cast
 
 import tensorstore as ts
 import xarray as xr
@@ -29,6 +30,9 @@ from xarray_tensorstore import (
 )
 
 logger = logging.getLogger(__name__)
+
+ZarrPath: TypeAlias = str | os.PathLike[str]
+ZarrSource: TypeAlias = ZarrPath | list[ZarrPath] | tuple[ZarrPath, ...]
 
 
 def _zarr_spec_from_path(path: str, zarr_format: int) -> dict[str, Any]:
@@ -90,7 +94,34 @@ def _tensorstore_open_zarrs(
     return arrays
 
 
-def open_zarr(
+def open_zarr_paths(zarr_path: ZarrSource, concat_dim: str | None = None) -> xr.Dataset:
+    """Open one or more Zarr stores using TensorStore.
+
+    Args:
+        zarr_path: A path, local glob pattern, or sequence of paths.
+        concat_dim: Dimension along which multiple stores are concatenated.
+    """
+    if isinstance(zarr_path, str | os.PathLike):
+        path = os.fspath(zarr_path)
+        if not has_magic(path):
+            return _open_single_zarr(path)
+        paths = sorted(glob(path))
+    else:
+        paths = [os.fspath(path) for path in zarr_path]
+
+    if not paths:
+        raise ValueError(f"No Zarr stores found for {zarr_path!r}")
+
+    if len(paths) == 1:
+        return _open_single_zarr(paths[0])
+
+    if concat_dim is None:
+        raise ValueError("`concat_dim` must be specified when opening multiple Zarr stores")
+
+    return _open_and_concat_zarrs(paths, concat_dim)
+
+
+def _open_single_zarr(
     path: str,
     context: ts.Context | None = None,
     mask_and_scale: bool = True,
@@ -129,12 +160,11 @@ def open_zarr(
     return cast("xr.Dataset", ds.copy(data=new_data))
 
 
-def open_zarrs(
+def _open_and_concat_zarrs(
     paths: list[str],
     concat_dim: str,
     context: ts.Context | None = None,
     mask_and_scale: bool = True,
-    data_source: str = "unknown",
 ) -> xr.Dataset:
     """Open multiple zarrs with TensorStore.
 
@@ -143,7 +173,6 @@ def open_zarrs(
         concat_dim: Dimension along which to concatenate the data variables.
         context: TensorStore context.
         mask_and_scale: Whether to mask and scale the data.
-        data_source: Which data source is being opened. Used for warning context.
 
     Returns:
         Concatenated Dataset with all data variables opened via TensorStore.
@@ -166,9 +195,8 @@ def open_zarrs(
         )
     except ValueError:
         logger.warning(
-            f"Coordinate mismatch found in {data_source} input data. Opening with "
-            "`join='override'` to ignore coordinate mismatches. THIS MAY CAUSE UNEXPECTED "
-            "BEHAVIOUR!",
+            f"Coordinate mismatch found when opening paths {paths}. Opening with `join='override'` "
+            "to ignore coordinate mismatches. THIS MAY CAUSE UNEXPECTED BEHAVIOUR.",
         )
         ds = xr.concat(
             ds_list,

--- a/src/ocf_data_sampler/config/model.py
+++ b/src/ocf_data_sampler/config/model.py
@@ -10,16 +10,8 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator, model_validator
 from typing_extensions import override
 
-NWP_PROVIDERS = [
-    "ukv",
-    "ecmwf",
-    "mo_global",
-    "gfs",
-    "icon_eu",
-    "cloudcasting",
-    "gencast",
-    "fgn",
-]
+from ocf_data_sampler.common.xr_tensorstore import ZarrSource
+from ocf_data_sampler.load.nwp import PROVIDER_REGISTRY
 
 
 class Base(BaseModel):
@@ -194,7 +186,7 @@ class NormalisationConstantsMixin(Base):
 class Satellite(TimeWindowMixin, DropoutMixin, SpatialWindowMixin, NormalisationConstantsMixin):
     """Satellite configuration model."""
 
-    zarr_path: str | tuple[str] | list[str] = Field(
+    zarr_path: ZarrSource = Field(
         ...,
         description="Absolute or relative zarr filepath(s). Prefix with a protocol like s3:// "
         "to read from alternative filesystems.",
@@ -221,7 +213,7 @@ class Satellite(TimeWindowMixin, DropoutMixin, SpatialWindowMixin, Normalisation
 class NWP(TimeWindowMixin, DropoutMixin, SpatialWindowMixin, NormalisationConstantsMixin):
     """NWP configuration model."""
 
-    zarr_path: str | tuple[str] | list[str] = Field(
+    zarr_path: ZarrSource = Field(
         ...,
         description="Absolute or relative zarr filepath(s). Prefix with a protocol like s3:// "
         "to read from alternative filesystems.",
@@ -242,7 +234,6 @@ class NWP(TimeWindowMixin, DropoutMixin, SpatialWindowMixin, NormalisationConsta
         " used to construct an example. If set to None, then the max staleness is set according to"
         " the maximum forecast horizon of the NWP and the requested forecast length.",
     )
-    public: bool = Field(False, description="Whether the NWP data is public or private")
 
     @model_validator(mode="after")
     def validate_accum_channels_subset(self) -> "NWP":
@@ -258,9 +249,11 @@ class NWP(TimeWindowMixin, DropoutMixin, SpatialWindowMixin, NormalisationConsta
     @field_validator("provider")
     def validate_provider(cls, v: str) -> str:
         """Validator for 'provider'."""
-        if v.lower() not in NWP_PROVIDERS:
-            raise OSError(f"NWP provider {v} is not in {NWP_PROVIDERS}")
-        return v
+        provider = v.lower()
+        if provider not in PROVIDER_REGISTRY:
+            supported = ", ".join(sorted(PROVIDER_REGISTRY))
+            raise ValueError(f"Unknown NWP provider {v!r}. Supported: {supported}")
+        return provider
 
 
     @model_validator(mode="after")
@@ -326,8 +319,6 @@ class Generation(TimeWindowMixin, DropoutMixin):
         description="Absolute or relative zarr filepath. Prefix with a protocol like s3:// "
         "to read from alternative filesystems.",
     )
-
-    public: bool = Field(False, description="Whether the NWP data is public or private")
 
 
 class SolarPosition(TimeWindowMixin):

--- a/src/ocf_data_sampler/datasets/pvnet/loading.py
+++ b/src/ocf_data_sampler/datasets/pvnet/loading.py
@@ -21,10 +21,7 @@ def get_dataset_dict(input_config: InputData) -> SourceDict[xr.DataArray]:
 
     # Load generation data unless the path is None
     if input_config.generation and input_config.generation.zarr_path:
-        da_generation = open_generation(
-            zarr_path=input_config.generation.zarr_path,
-            public=input_config.generation.public,
-        )
+        da_generation = open_generation(zarr_path=input_config.generation.zarr_path)
 
         # Remove location_id 0 if more than one location present
         if len(da_generation["location_id"]) > 1 and 0 in da_generation["location_id"].values:
@@ -39,11 +36,7 @@ def get_dataset_dict(input_config: InputData) -> SourceDict[xr.DataArray]:
     if input_config.nwp:
         datasets_dict["nwp"] = {}
         for nwp_source, nwp_config in input_config.nwp.items():
-            da_nwp = open_nwp(
-                zarr_path=nwp_config.zarr_path,
-                provider=nwp_config.provider,
-                public=nwp_config.public,
-            )
+            da_nwp = open_nwp(zarr_path=nwp_config.zarr_path, provider=nwp_config.provider)
 
             da_nwp = da_nwp.sel(channel=list(nwp_config.channels))
 

--- a/src/ocf_data_sampler/load/conventions.py
+++ b/src/ocf_data_sampler/load/conventions.py
@@ -1,12 +1,47 @@
 """Helpers that conform freshly opened data to package conventions."""
 
+from collections.abc import Mapping
+
 import numpy as np
 import xarray as xr
 
 from ocf_data_sampler.common.indexing import assert_values_unique_increasing
 
 
-def make_spatial_coords_increasing(ds: xr.Dataset, x_coord: str, y_coord: str) -> xr.Dataset:
+def validate_coords(
+    data: xr.Dataset | xr.DataArray,
+    expected_dtypes: Mapping[str, type[np.generic]],
+    source: str,
+) -> None:
+    """Validate required coordinate presence, dimensionality, and dtypes.
+
+    Args:
+        data: Xarray object containing the coordinates.
+        expected_dtypes: Mapping from coordinate names to expected NumPy dtype classes.
+        source: Description of the data source used in validation errors.
+    """
+    for coord, expected_dtype in expected_dtypes.items():
+        if coord not in data.coords:
+            raise ValueError(f"Expected coordinate {coord!r} missing from {source}")
+
+        if (ndim := data[coord].ndim) != 1:
+            raise ValueError(
+                f"Coordinate {coord!r} in {source} should be 1D, not {ndim}D",
+            )
+
+        actual_dtype = data[coord].dtype
+        if not np.issubdtype(actual_dtype, expected_dtype):
+            raise TypeError(
+                f"Coordinate {coord!r} in {source} should be "
+                f"{expected_dtype.__name__}, not {actual_dtype.name}",
+            )
+
+
+def make_spatial_coords_increasing(
+    ds: xr.Dataset | xr.DataArray,
+    x_coord: str,
+    y_coord: str,
+) -> xr.Dataset | xr.DataArray:
     """Make sure the spatial coordinates are in increasing order.
 
     Args:
@@ -31,15 +66,21 @@ def make_spatial_coords_increasing(ds: xr.Dataset, x_coord: str, y_coord: str) -
     return ds
 
 
-def get_xr_data_array_from_xr_dataset(ds: xr.Dataset) -> xr.DataArray:
+def extract_single_data_array(ds: xr.Dataset, promote_attrs: bool = True) -> xr.DataArray:
     """Return underlying xr.DataArray from passed xr.Dataset.
 
     Checks only one variable is present and returns it as an xr.DataArray.
 
     Args:
         ds: xr.Dataset to extract xr.DataArray from
+        promote_attrs: Whether to promote dataset attributes to the data array
     """
     datavars = list(ds.data_vars)
     if len(datavars) != 1:
-        raise ValueError("Cannot open as xr.DataArray: dataset contains multiple variables")
-    return ds[datavars[0]]
+        raise ValueError(
+            f"Cannot extract a single DataArray: dataset contains variables {datavars}",
+        )
+    da = ds[datavars[0]]
+    if promote_attrs:
+        da.attrs.update(ds.attrs)
+    return da

--- a/src/ocf_data_sampler/load/generation.py
+++ b/src/ocf_data_sampler/load/generation.py
@@ -4,50 +4,57 @@ Generation data schema: a Zarr file with the following data variables and dimens
 
 Dimensions: (time_utc, location_id)
 Data Variables:
-    generation_mw (time_utc, location_id): float32 representing the generation in MW
-    capacity_mwp (time_utc, location_id): float32 representing the capacity in MW peak
+    generation_mw (time_utc, location_id): The generation in MW
+    capacity_mwp (time_utc, location_id): The capacity in MW peak
 Coordinates:
-    time_utc (time_utc): datetime64[ns] representing the time in utc
-    location_id (location_id): int representing the location IDs
-    longitute (location_id): float representing the longitudes of the locations
-    latitude (location_id): float representing the latitudes of the locations
+    time_utc (time_utc): The datetimes associated with each generation and capacity value
+    location_id (location_id): The integer IDs of the locations
+    longitude (location_id): The longitudes of the locations
+    latitude (location_id): The latitudes of the locations
 
 """
 
 import numpy as np
 import xarray as xr
 
-from ocf_data_sampler.load.conventions import assert_values_unique_increasing
+from ocf_data_sampler.common.indexing import assert_values_unique_increasing
+from ocf_data_sampler.load.conventions import validate_coords
 
 
-def open_generation(zarr_path: str, public: bool = False) -> xr.DataArray:
+def open_generation(zarr_path: str) -> xr.DataArray:
     """Open and eagerly load the generation data and validates its data types.
 
     Args:
         zarr_path: Path to the generation zarr data
-        public: Whether the data is public or private.
 
     Returns:
         xr.DataArray: The opened generation data
     """
-    backend_kwargs = {}
-    # Open the generation data
-    if public:
-        backend_kwargs = {"storage_options": {"anon": True}}
-        # Currently only compatible with S3 bucket.
-
-    ds = xr.open_dataset(
-        zarr_path,
-        engine="zarr",
-        chunks=None,
-        backend_kwargs=backend_kwargs,
-    )
+    # Open generation without xarray-tensorstore since it has multiple data-variables
+    # TODO: establish if xarray tensorstore could be used here
+    ds = xr.open_dataset(zarr_path, engine="zarr", chunks=None)
 
     if set(ds.data_vars) != {"generation_mw", "capacity_mwp"}:
         raise ValueError(
             f"Generation data should have variables 'generation_mw' and 'capacity_mwp', "
             f"but found {set(ds.data_vars)} instead."
         )
+
+    coord_dtypes = {
+        "time_utc": np.datetime64,
+        "location_id": np.integer,
+        "longitude": np.number,
+        "latitude": np.number,
+    }
+    validate_coords(
+        ds,
+        coord_dtypes,
+        source="generation data",
+    )
+
+    # Load the data eagerly into memory - this makes the dataset faster to sample from, but
+    # at the cost of a little extra memory usage
+    ds = ds.load()
 
     da = ds.to_dataarray("gen_param").transpose("time_utc", "location_id", "gen_param")
 
@@ -58,18 +65,4 @@ def open_generation(zarr_path: str, public: bool = False) -> xr.DataArray:
     if not np.issubdtype(da.dtype, np.floating):
         raise TypeError(f"generation and capacity values should be floating, not {da.dtype}")
 
-    coord_dtypes = {
-        "time_utc": np.datetime64,
-        "location_id": np.integer,
-        "longitude": np.floating,
-        "latitude": np.floating,
-    }
-
-    for coord, expected_dtype in coord_dtypes.items():
-        if not np.issubdtype(da.coords[coord].dtype, expected_dtype):
-            dtype = da.coords[coord].dtype
-            raise TypeError(f"{coord} should be {expected_dtype.__name__}, not {dtype}")
-
-    # Below we load the data eagerly into memory - this makes the dataset faster to sample from, but
-    # at the cost of a little extra memory usage
-    return da.load()
+    return da

--- a/src/ocf_data_sampler/load/nwp.py
+++ b/src/ocf_data_sampler/load/nwp.py
@@ -1,285 +1,79 @@
 """Module for opening NWP data."""
 
 
-from glob import glob
-from typing import TYPE_CHECKING, Literal
+from collections.abc import Mapping
 
 import numpy as np
 import xarray as xr
 
 from ocf_data_sampler.common.indexing import assert_values_unique_increasing
-from ocf_data_sampler.common.xr_tensorstore import open_zarr, open_zarrs
+from ocf_data_sampler.common.xr_tensorstore import ZarrSource, open_zarr_paths
 from ocf_data_sampler.load.conventions import (
-    get_xr_data_array_from_xr_dataset,
+    extract_single_data_array,
     make_spatial_coords_increasing,
+    validate_coords,
 )
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
+SpatialCoords = tuple[str, str]
+
+# This is our central registry of NWP providers and their spatial coordinate names, which allows us
+# to handle different providers in a consistent way.
+PROVIDER_REGISTRY: dict[str, SpatialCoords] = {
+    "ukv": ("x_osgb", "y_osgb"),
+    "ecmwf": ("longitude", "latitude"),
+    "mo_global": ("longitude", "latitude"),
+    "gencast": ("longitude", "latitude"),
+    "fgn": ("longitude", "latitude"),
+    "cloudcasting": ("x_geostationary", "y_geostationary"),
+}
 
 
-def open_zarr_paths(
-    zarr_path: str | list[str],
-    time_dim: str,
-    backend: Literal["dask", "tensorstore"],
-    public: bool = False,
-) -> xr.Dataset:
-    """Opens the NWP data.
-
-    Args:
-        zarr_path: Path to the zarr(s) to open
-        time_dim: Name of the time dimension
-        public: Whether the data is public or private. Only available for the dask backend.
-        backend: The xarray backend to use.
-
-    Returns:
-        The opened Xarray Dataset
-    """
-    if backend not in ["dask", "tensorstore"]:
-        raise ValueError(
-            f"Unsupported backend: {backend}. Supported backends are 'dask' and 'tensorstore'.",
-        )
-
-    if public and backend == "tensorstore":
-        raise ValueError("Public data is only supported with the 'dask' backend.")
-
-    if backend == "tensorstore":
-        ds = _tensorstore_open_zarr_paths(zarr_path, time_dim)
-
-    elif backend == "dask":
-        ds = _dask_open_zarr_paths(zarr_path, time_dim, public)
-
-    return ds
-
-
-def _dask_open_zarr_paths(zarr_path: str | list[str], time_dim: str, public: bool) -> xr.Dataset:
-    general_kwargs = {
-        "engine": "zarr",
-        "chunks": "auto",
-        "decode_timedelta": True,
-    }
-
-    if public:
-        # note this only works for s3 zarr paths at the moment
-        general_kwargs["storage_options"] = {"anon": True}
-
-    if isinstance(zarr_path, list | tuple) or "*" in str(zarr_path):  # Multi-file dataset
-        ds = xr.open_mfdataset(
-            zarr_path,
-            concat_dim=time_dim,
-            combine="nested",
-            coords="different",
-            compat="no_conflicts",
-            **general_kwargs,
-        ).sortby(time_dim)
-    else:
-        ds = xr.open_dataset(
-            zarr_path,
-            consolidated=True,
-            mode="r",
-            **general_kwargs,
-        )
-    return ds
-
-
-def _tensorstore_open_zarr_paths(zarr_path: str | list[str], time_dim: str) -> xr.Dataset:
-
-    if "*" in str(zarr_path):
-        zarr_path = sorted(glob(zarr_path))
-
-    if isinstance(zarr_path, list | tuple):
-        ds = open_zarrs(zarr_path, concat_dim=time_dim, data_source="nwp").sortby(time_dim)
-    else:
-        ds = open_zarr(zarr_path)
-    return ds
-
-
-def _validate_nwp_data(data_array: xr.DataArray, provider: str) -> None:
-    """Validates the structure and data types of a loaded NWP DataArray.
-
-    This helper function is extracted to keep the main `open_nwp` function clean.
-
-    Args:
-        data_array: The xarray.DataArray to validate.
-        provider: The NWP provider name.
-
-    Raises:
-        TypeError: If the data or any coordinate has an unexpected dtype.
-        ValueError: If a required coordinate is missing.
-    """
-    if not np.issubdtype(data_array.dtype, np.number):
-        raise TypeError(
-            f"NWP data for {provider} should be numeric, not {data_array.dtype}",
-        )
-
-    common_expected_dtypes = {
-        "init_time_utc": np.datetime64,
-        "step": np.timedelta64,
-    }
-
-    geographic_spatial_dtypes = {
-        "latitude": np.floating,
-        "longitude": np.floating,
-    }
-
-    provider_specific_spatial_dtypes = {
-        "ecmwf": geographic_spatial_dtypes,
-        "icon-eu": geographic_spatial_dtypes,
-        "gfs": geographic_spatial_dtypes,
-        "mo_global": geographic_spatial_dtypes,
-        "ukv": {
-            "x_osgb": np.number,
-            "y_osgb": np.number,
-        },
-        "cloudcasting": {
-            "x_geostationary": np.floating,
-            "y_geostationary": np.floating,
-        },
-    }
-
-    expected_dtypes = {
-        **common_expected_dtypes,
-        **provider_specific_spatial_dtypes.get(provider, {}),
-    }
-
-    for coord, expected_dtype in expected_dtypes.items():
-        if coord not in data_array.coords:
-            raise ValueError(f"Coordinate '{coord}' missing for provider '{provider}'")
-
-        actual_dtype = data_array.coords[coord].dtype
-
-        if not np.issubdtype(actual_dtype, expected_dtype):
-            if isinstance(expected_dtype, tuple):
-                expected_name_str = " or ".join([t.__name__ for t in expected_dtype])
-            else:
-                expected_name_str = expected_dtype.__name__
-
-            err_msg = (
-                f"'{coord}' for {provider} should be {expected_name_str}, "
-                f"not {actual_dtype.name}"
-            )
-            raise TypeError(err_msg)
-
-
-def open_nwp(
-    zarr_path: str | list[str],
-    provider: str,
-    public: bool = False,
-) -> xr.DataArray:
-    """Opens NWP zarr and validates its structure and data types.
-
-    Args:
-        zarr_path: path to the zarr file
-        provider: NWP provider
-        public: Whether the data is public or private (only for GFS)
-    """
+def open_nwp(zarr_path: ZarrSource, provider: str) -> xr.DataArray:
+    """Open NWP data and conform it to the standard layout."""
     provider = provider.lower()
 
-    _OPEN_NWP_FUNCTIONS: dict[str, Callable[..., xr.DataArray]] = {
-        "ukv": open_ukv,
-        "ecmwf": open_standard_lon_lat_grid,
-        "mo_global": open_standard_lon_lat_grid,
-        "icon-eu": open_icon_eu,
-        "gencast": open_standard_lon_lat_grid,
-        "fgn": open_standard_lon_lat_grid,
-        "gfs": open_gfs,
-        "cloudcasting": open_cloudcasting,
-    }
-
-    if provider not in _OPEN_NWP_FUNCTIONS:
-        supported = ", ".join(sorted(_OPEN_NWP_FUNCTIONS.keys()))
+    if provider not in PROVIDER_REGISTRY:
+        supported = ", ".join(sorted(PROVIDER_REGISTRY))
         raise ValueError(f"Unknown provider: {provider!r}. Supported: {supported}")
 
-    opener = _OPEN_NWP_FUNCTIONS[provider]
+    x_coord, y_coord = PROVIDER_REGISTRY[provider]
 
-    kwargs = {"zarr_path": zarr_path}
-    if provider == "gfs" and public:
-        kwargs["public"] = True
+    ds = open_zarr_paths(zarr_path, concat_dim="init_time_utc")
+    ds = _rename(ds, name_mapping={"variable": "channel"})
 
-    data_array = opener(**kwargs)
-    _validate_nwp_data(data_array, provider)
-    return data_array
-
-
-def _canonicalize_regular_grid_layout(
-    ds: xr.Dataset | xr.DataArray,
-    x_coord: str,
-    y_coord: str,
-) -> xr.DataArray:
-    """Shared post-processing for any regular-grid NWP dataset.
-
-    Expects dims/coords already standardised to: init_time_utc, step, channel,
-    plus the given x_coord/y_coord spatial dims.
-    """
-    assert_values_unique_increasing(ds["init_time_utc"].values, "init_time_utc")
-    ds = make_spatial_coords_increasing(ds, x_coord=x_coord, y_coord=y_coord)
-    ds = ds.transpose("init_time_utc", "step", "channel", x_coord, y_coord)
-
-    if isinstance(ds, xr.Dataset):
-        return get_xr_data_array_from_xr_dataset(ds)
-    return ds
-
-
-def open_standard_lon_lat_grid(zarr_path: str | list[str]) -> xr.DataArray:
-    """Opens NWP data on a standard latitude/longitude grid.
-
-    Used by ECMWF IFS, MetOffice Global, GDM (e.g. GenCast & FGN).
-    Pass time_dim="init_time_utc" for zarrs that already use the new dim name.
-    """
-    ds = open_zarr_paths(zarr_path, backend="tensorstore", time_dim="init_time_utc")
-    rename_map = {"variable": "channel"}
-    ds = ds.rename({k: v for k, v in rename_map.items() if k in ds.coords})
-    return _canonicalize_regular_grid_layout(ds, x_coord="longitude", y_coord="latitude")
-
-
-def open_gfs(zarr_path: str | list[str], public: bool = False) -> xr.DataArray:
-    """Opens GFS NWP data."""
-    ds = open_zarr_paths(
-        zarr_path,
-        time_dim="init_time_utc",
-        public=public,
-        backend="dask",
-    )
-    da = ds.to_array(dim="channel")
-    return _canonicalize_regular_grid_layout(da, x_coord="longitude", y_coord="latitude")
-
-
-def open_icon_eu(zarr_path: str | list[str]) -> xr.DataArray:
-    """Opens DWD ICON-EU data.
-
-    ICON-EU is expected to be on a regular lat/lon grid with a 'channel' dim.
-    Only the first 78 (one-hour) steps are used; the rest are 3-hour steps.
-    """
-    ds = open_zarr_paths(zarr_path, time_dim="init_time_utc", backend="dask")
-    if "icon_eu_data" not in ds.data_vars:
-        raise ValueError("Could not find 'icon_eu_data' DataArray in the ICON-EU Zarr file.")
-    nwp = ds["icon_eu_data"].isel(step=slice(0, 78))
-    return _canonicalize_regular_grid_layout(nwp, x_coord="longitude", y_coord="latitude")
-
-
-def open_ukv(zarr_path: str | list[str]) -> xr.DataArray:
-    """Opens UKV NWP data (OSGB grid)."""
-    ds = open_zarr_paths(zarr_path, backend="tensorstore", time_dim="init_time_utc")
-    # Only rename keys actually present - new UKV data already uses the target names
-    rename_map = {
-        "variable": "channel",
-        "x": "x_osgb",
-        "y": "y_osgb",
+    expected_coord_dtypes = {
+        "init_time_utc": np.datetime64,
+        "step": np.timedelta64,
+        "channel": np.str_,
+        x_coord: np.number,
+        y_coord: np.number,
     }
-    ds = ds.rename({k: v for k, v in rename_map.items() if k in ds.coords})
-    return _canonicalize_regular_grid_layout(ds, x_coord="x_osgb", y_coord="y_osgb")
-
-
-def open_cloudcasting(zarr_path: str | list[str]) -> xr.DataArray:
-    """Opens OCF cloudcasting satellite-prediction data (geostationary grid).
-
-    References:
-        [1] https://www.openclimatefix.org/projects/cloud-forecasting
-        [2] https://github.com/ClimeTrend/cloudcasting
-        [3] https://github.com/openclimatefix/sat_pred
-    """
-    ds = open_zarr_paths(zarr_path, time_dim="init_time_utc", backend="tensorstore")
-    ds = ds.rename({"variable": "channel"})
-    return _canonicalize_regular_grid_layout(
-        ds, x_coord="x_geostationary", y_coord="y_geostationary",
+    validate_coords(
+        ds,
+        expected_coord_dtypes,
+        source=f"NWP provider {provider!r}",
     )
+
+    ds = make_spatial_coords_increasing(ds, x_coord=x_coord, y_coord=y_coord)
+
+    assert_values_unique_increasing(ds["init_time_utc"].values, "init_time_utc")
+    assert_values_unique_increasing(ds["step"].values, "step")
+
+    da = extract_single_data_array(ds)
+    da = da.transpose("init_time_utc", "step", "channel", x_coord, y_coord)
+
+    if not np.issubdtype(da.dtype, np.floating):
+        raise TypeError(f"NWP data for {provider} should be floating, not {da.dtype}")
+
+    return da
+
+
+def _rename(ds: xr.Dataset, name_mapping: Mapping[str, str]) -> xr.Dataset:
+    """Renames coordinates in the dataset based on the provided mapping.
+
+    Args:
+        ds: The xarray.Dataset to rename.
+        name_mapping: A dictionary mapping old variable names to new names.
+    """
+    # Only rename variables that are actually present in the dataset
+    return ds.rename({k: v for k, v in name_mapping.items() if k in ds})

--- a/src/ocf_data_sampler/load/nwp.py
+++ b/src/ocf_data_sampler/load/nwp.py
@@ -16,7 +16,7 @@ from ocf_data_sampler.load.conventions import (
 
 SpatialCoords = tuple[str, str]
 
-# This is our central registry of NWP providers and their spatial coordinate names, which allows us
+# This is our central registry of NWP providers and their spatial coordinate names, which allows us
 # to handle different providers in a consistent way.
 PROVIDER_REGISTRY: dict[str, SpatialCoords] = {
     "ukv": ("x_osgb", "y_osgb"),

--- a/src/ocf_data_sampler/load/satellite.py
+++ b/src/ocf_data_sampler/load/satellite.py
@@ -1,67 +1,44 @@
 """Satellite loader."""
-import json
 
 import numpy as np
 import xarray as xr
 
 from ocf_data_sampler.common.indexing import assert_values_unique_increasing
-from ocf_data_sampler.common.xr_tensorstore import open_zarr, open_zarrs
+from ocf_data_sampler.common.xr_tensorstore import ZarrSource, open_zarr_paths
 from ocf_data_sampler.load.conventions import (
-    get_xr_data_array_from_xr_dataset,
+    extract_single_data_array,
     make_spatial_coords_increasing,
+    validate_coords,
 )
 
 
-def open_sat_data(zarr_path: str | list[str]) -> xr.DataArray:
+def open_sat_data(zarr_path: ZarrSource) -> xr.DataArray:
     """Lazily opens the zarr store and validates data types.
 
     Args:
-      zarr_path: Cloud URL or local path pattern, or list of these. If GCS URL,
-                 it must start with 'gs://'
+        zarr_path: Path(s) to the zarr file(s)
     """
-    # Open the data
-    if isinstance(zarr_path, list | tuple):
-        ds = open_zarrs(zarr_path, concat_dim="time", data_source="satellite")
-    else:
-        ds = open_zarr(zarr_path)
-
-    rename_dict = {
-        "variable": "channel",
-        "time": "time_utc",
-    }
-
-    for old_name, new_name in list(rename_dict.items()):
-        if old_name not in ds:
-            if new_name in ds:
-                del rename_dict[old_name]
-            else:
-                raise KeyError(f"Expected either '{old_name}' or '{new_name}' to be in dataset")
-    ds = ds.rename(rename_dict)
-
-    ds = make_spatial_coords_increasing(ds, x_coord="x_geostationary", y_coord="y_geostationary")
-    assert_values_unique_increasing(ds["time_utc"].values, "time_utc")
-    ds = ds.transpose("time_utc", "channel", "x_geostationary", "y_geostationary")
-
-    da = get_xr_data_array_from_xr_dataset(ds)
-
-    # Copy the area attribute if missing
-    if "area" not in da.attrs:
-        da.attrs["area"] = json.dumps(ds.attrs["area"])
-
-    # Validate data types directly loading function
-    if not np.issubdtype(da.dtype, np.number):
-        raise TypeError(f"Satellite data should be numeric, not {da.dtype}")
+    ds = open_zarr_paths(zarr_path, concat_dim="time_utc")
 
     coord_dtypes = {
         "time_utc": np.datetime64,
         "channel": np.str_,
-        "x_geostationary": np.floating,
-        "y_geostationary": np.floating,
+        "x_geostationary": np.number,
+        "y_geostationary": np.number,
     }
+    validate_coords(
+        ds,
+        coord_dtypes,
+        source="satellite data",
+    )
 
-    for coord, expected_dtype in coord_dtypes.items():
-        if not np.issubdtype(da.coords[coord].dtype, expected_dtype):
-            dtype = da.coords[coord].dtype
-            raise TypeError(f"{coord} should be {expected_dtype.__name__}, not {dtype}")
+    ds = make_spatial_coords_increasing(ds, x_coord="x_geostationary", y_coord="y_geostationary")
+    assert_values_unique_increasing(ds["time_utc"].values, "time_utc")
+
+    da = extract_single_data_array(ds)
+    da = da.transpose("time_utc", "channel", "x_geostationary", "y_geostationary")
+
+    if not np.issubdtype(da.dtype, np.floating):
+        raise TypeError(f"Satellite data should be floating, not {da.dtype}")
 
     return da

--- a/tests/common/test_xr_tensorstore.py
+++ b/tests/common/test_xr_tensorstore.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from ocf_data_sampler.common.xr_tensorstore import open_zarr, open_zarrs
+from ocf_data_sampler.common.xr_tensorstore import _open_single_zarr, _open_and_concat_zarrs
 
 
 @pytest.fixture(scope="module")
@@ -40,13 +40,13 @@ def nwp_like_zarr3_paths(session_tmp_path, concatable_nwp_like_data):
 
 def test_open_zarr(nwp_like_zarr2_paths, nwp_like_zarr3_paths):
     # Check function can open zarr2
-    ds_ts = open_zarr(nwp_like_zarr2_paths[0])
+    ds_ts = _open_single_zarr(nwp_like_zarr2_paths[0])
     # Check tensorstore version returns same results as dask version
     ds_dask = xr.open_zarr(nwp_like_zarr2_paths[0])
     assert ds_ts.compute().equals(ds_dask.compute())
 
     # Check function can open zarr3
-    ds_ts = open_zarr(nwp_like_zarr3_paths[0])
+    ds_ts = _open_single_zarr(nwp_like_zarr3_paths[0])
     # Check tensorstore version returns same results as dask version
     ds_dask = xr.open_zarr(nwp_like_zarr3_paths[0])
     assert ds_ts.compute().equals(ds_dask.compute())
@@ -54,14 +54,14 @@ def test_open_zarr(nwp_like_zarr2_paths, nwp_like_zarr3_paths):
 
 def test_open_zarrs(nwp_like_zarr2_paths, nwp_like_zarr3_paths):
     # Check function can open zarr2
-    ds_ts = open_zarrs(nwp_like_zarr2_paths, concat_dim="init_time_utc")
+    ds_ts = _open_and_concat_zarrs(nwp_like_zarr2_paths, concat_dim="init_time_utc")
     # Check tensorstore version returns same results as dask version
     kwargs = {"concat_dim": "init_time_utc", "combine": "nested", "engine": "zarr"}
     ds_dask = xr.open_mfdataset(nwp_like_zarr2_paths, **kwargs)
     assert ds_ts.compute().equals(ds_dask.compute())
 
     # Check function can open zarr3
-    ds_ts = open_zarrs(nwp_like_zarr3_paths, concat_dim="init_time_utc")
+    ds_ts = _open_and_concat_zarrs(nwp_like_zarr3_paths, concat_dim="init_time_utc")
     # Check tensorstore version returns same results as dask version
     ds_dask = xr.open_mfdataset(nwp_like_zarr3_paths, **kwargs)
     assert ds_ts.compute().equals(ds_dask.compute())

--- a/tests/common/test_xr_tensorstore.py
+++ b/tests/common/test_xr_tensorstore.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from ocf_data_sampler.common.xr_tensorstore import _open_and_concat_zarrs, _open_single_zarr
+from ocf_data_sampler.common.xr_tensorstore import open_zarr_paths
 
 
 @pytest.fixture(scope="module")
@@ -38,30 +38,30 @@ def nwp_like_zarr3_paths(session_tmp_path, concatable_nwp_like_data):
     return _save_nwp_zarr(session_tmp_path, concatable_nwp_like_data, 3)
 
 
-def test_open_zarr(nwp_like_zarr2_paths, nwp_like_zarr3_paths):
+def test_open_single_zarr(nwp_like_zarr2_paths, nwp_like_zarr3_paths):
     # Check function can open zarr2
-    ds_ts = _open_single_zarr(nwp_like_zarr2_paths[0])
+    ds_ts = open_zarr_paths(nwp_like_zarr2_paths[0])
     # Check tensorstore version returns same results as dask version
     ds_dask = xr.open_zarr(nwp_like_zarr2_paths[0])
     assert ds_ts.compute().equals(ds_dask.compute())
 
     # Check function can open zarr3
-    ds_ts = _open_single_zarr(nwp_like_zarr3_paths[0])
+    ds_ts = open_zarr_paths(nwp_like_zarr3_paths[0])
     # Check tensorstore version returns same results as dask version
     ds_dask = xr.open_zarr(nwp_like_zarr3_paths[0])
     assert ds_ts.compute().equals(ds_dask.compute())
 
 
-def test_open_zarrs(nwp_like_zarr2_paths, nwp_like_zarr3_paths):
+def test_open_multi_zarrs(nwp_like_zarr2_paths, nwp_like_zarr3_paths):
     # Check function can open zarr2
-    ds_ts = _open_and_concat_zarrs(nwp_like_zarr2_paths, concat_dim="init_time_utc")
+    ds_ts = open_zarr_paths(nwp_like_zarr2_paths, concat_dim="init_time_utc")
     # Check tensorstore version returns same results as dask version
     kwargs = {"concat_dim": "init_time_utc", "combine": "nested", "engine": "zarr"}
     ds_dask = xr.open_mfdataset(nwp_like_zarr2_paths, **kwargs)
     assert ds_ts.compute().equals(ds_dask.compute())
 
     # Check function can open zarr3
-    ds_ts = _open_and_concat_zarrs(nwp_like_zarr3_paths, concat_dim="init_time_utc")
+    ds_ts = open_zarr_paths(nwp_like_zarr3_paths, concat_dim="init_time_utc")
     # Check tensorstore version returns same results as dask version
     ds_dask = xr.open_mfdataset(nwp_like_zarr3_paths, **kwargs)
     assert ds_ts.compute().equals(ds_dask.compute())

--- a/tests/common/test_xr_tensorstore.py
+++ b/tests/common/test_xr_tensorstore.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from ocf_data_sampler.common.xr_tensorstore import _open_single_zarr, _open_and_concat_zarrs
+from ocf_data_sampler.common.xr_tensorstore import _open_and_concat_zarrs, _open_single_zarr
 
 
 @pytest.fixture(scope="module")

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -66,8 +66,18 @@ def test_incorrect_nwp_provider(config_filename):
     """
     configuration, provider = _load_config_and_provider(config_filename)
     configuration.input_data.nwp[provider].provider = "unexpected_provider"
-    with pytest.raises(Exception, match="NWP provider"):
+    with pytest.raises(ValidationError, match="Unknown NWP provider"):
         _validate_configuration(configuration)
+
+
+def test_nwp_provider_is_canonicalized(config_filename):
+    """NWP provider names are stored using their canonical lowercase spelling."""
+    configuration, provider = _load_config_and_provider(config_filename)
+    configuration.input_data.nwp[provider].provider = "UKV"
+
+    validated = _validate_configuration(configuration)
+
+    assert validated.input_data.nwp[provider].provider == "ukv"
 
 
 def test_incorrect_dropout(config_filename):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,8 +96,8 @@ def sat_zarr_path(session_tmp_path):
     ds = xr.DataArray(
         data,
         coords={
-            "variable": variables,
-            "time": pd.date_range("2023-01-01 00:00", "2023-01-01 23:55", freq="5min"),
+            "channel": variables,
+            "time_utc": pd.date_range("2023-01-01 00:00", "2023-01-01 23:55", freq="5min"),
             "y_geostationary": np.linspace(4191563, 5304712, 100),
             "x_geostationary": np.linspace(15002, -1824245, 100),
         },
@@ -114,8 +114,8 @@ def ds_nwp_ukv(session_rng):
         "init_time_utc": pd.date_range("2023-01-01 00:00", freq="180min", periods=24 * 7),
         "variable": ["si10", "dswrf", "t", "prate"],
         "step": pd.timedelta_range("0h", "10h", freq="1h"),
-        "x": np.linspace(-239_000, 857_000, 50),
-        "y": np.linspace(-183_000, 1225_000, 100),
+        "x_osgb": np.linspace(-239_000, 857_000, 50),
+        "y_osgb": np.linspace(-183_000, 1225_000, 100),
     }
     shape = tuple(len(v) for v in coords.values())
     data = session_rng.uniform(0, 200, shape).astype(np.float32)
@@ -124,7 +124,13 @@ def ds_nwp_ukv(session_rng):
 
 @pytest.fixture(scope="session")
 def nwp_ukv_zarr_path(session_tmp_path, ds_nwp_ukv):
-    chunks = {"init_time_utc": 1, "step": -1, "variable": -1, "x": 50, "y": 50}
+    chunks = {
+        "init_time_utc": 1,
+        "step": -1,
+        "variable": -1,
+        "x_osgb": 50,
+        "y_osgb": 50,
+    }
     yield save_zarr(ds_nwp_ukv, session_tmp_path, "ukv_nwp.zarr", chunks)
 
 
@@ -161,51 +167,6 @@ def ds_nwp_ecmwf(session_rng):
 def nwp_ecmwf_zarr_path(session_tmp_path, ds_nwp_ecmwf):
     chunks = {"init_time_utc": 1, "step": -1, "variable": -1, "longitude": 50, "latitude": 50}
     yield save_zarr(ds_nwp_ecmwf, session_tmp_path, "ecmwf_nwp.zarr", chunks)
-
-
-@pytest.fixture(scope="session")
-def icon_eu_zarr_path(session_tmp_path, session_rng):
-    step = pd.timedelta_range("0h", "5D", freq="1h")
-    channels = np.array(["t_1000hPa", "u_10m", "v_10m"], dtype=str)
-    lat = np.linspace(29.5, 35.69, 100)
-    lon = np.linspace(-23.5, -17.31, 100)
-
-    attrs = {
-        "Conventions": "CF-1.7",
-        "GRIB_centre": "edzw",
-        "GRIB_centreDescription": "Offenbach",
-        "GRIB_edition": 2,
-        "institution": "Offenbach",
-    }
-
-    paths = []
-    for hour in ["00", "06"]:
-        data = session_rng.random((len(step), len(channels), len(lat), len(lon))).astype(np.float32)
-        time_utc = pd.Timestamp(f"2021-11-01T{hour}:00:00")
-
-        da = xr.DataArray(
-            data,
-            coords={
-                "step": step,
-                "channel": channels,
-                "longitude": lon,
-                "latitude": lat,
-                "init_time_utc": time_utc,
-            },
-            dims=("step", "channel", "longitude", "latitude"),
-            attrs=attrs,
-        )
-        da.coords["valid_time"] = da.init_time_utc + da.step
-
-        paths.append(
-            save_zarr(
-                da.to_dataset(name="icon_eu_data"),
-                session_tmp_path,
-                f"20211101_{hour}.zarr",
-            ),
-        )
-
-    return paths
 
 
 @pytest.fixture(scope="session")

--- a/tests/datasets/pvnet/test_materialise.py
+++ b/tests/datasets/pvnet/test_materialise.py
@@ -2,7 +2,7 @@ import dask.array
 import numpy as np
 import xarray as xr
 
-from ocf_data_sampler.common.xr_tensorstore import open_zarr
+from ocf_data_sampler.common.xr_tensorstore import _open_single_zarr
 from ocf_data_sampler.datasets.pvnet.materialise import load, load_data_dict
 
 
@@ -30,7 +30,7 @@ def test_load_data_dict(tmp_path):
     da_dask.to_dataset(name="dummy_array").to_zarr(tmp_path)
 
     # Re-open with tensorstore
-    da_ts = open_zarr(tmp_path).dummy_array
+    da_ts = _open_single_zarr(tmp_path).dummy_array
 
     # Create a nested dictionary with tensorstore arrays
     lazy_data_dict = {

--- a/tests/load/test_conventions.py
+++ b/tests/load/test_conventions.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from ocf_data_sampler.load.conventions import validate_coords
+
+
+def test_validate_coords_rejects_multidimensional_coord():
+    ds = xr.Dataset(
+        coords={
+            "latitude": (
+                ("x", "y"),
+                np.array([[50.0, 51.0], [52.0, 53.0]]),
+            ),
+        },
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Coordinate 'latitude' in test data should be 1D, not 2D",
+    ):
+        validate_coords(
+            ds,
+            {"latitude": np.number},
+            source="test data",
+        )

--- a/tests/load/test_load_nwp.py
+++ b/tests/load/test_load_nwp.py
@@ -21,14 +21,6 @@ def test_load_ecmwf(nwp_ecmwf_zarr_path):
     assert len(np.unique(da.coords["channel"])) == da.shape[2]
 
 
-def test_load_icon_eu(icon_eu_zarr_path):
-    da = open_nwp(zarr_path=icon_eu_zarr_path, provider="icon-eu")
-    assert isinstance(da, DataArray)
-    assert da.dims == ("init_time_utc", "step", "channel", "longitude", "latitude")
-    assert da.shape == (2, 78, 3, 100, 100)
-    assert len(np.unique(da.coords["channel"])) == da.shape[2]
-
-
 def test_load_cloudcasting(nwp_cloudcasting_zarr_path):
     da = open_nwp(zarr_path=nwp_cloudcasting_zarr_path, provider="cloudcasting")
     assert isinstance(da, DataArray)
@@ -62,18 +54,31 @@ def test_load_ukv_new_coords(tmp_path):
     assert "x_osgb" in da.coords
     assert "y_osgb" in da.coords
 
-@pytest.mark.skip(reason="Fixture 'nwp_gfs_zarr_path' is not yet defined.")
-def test_load_gfs(nwp_gfs_zarr_path):
-    da = open_nwp(zarr_path=nwp_gfs_zarr_path, provider="gfs")
-    assert isinstance(da, DataArray)
-    assert da.dims == ("init_time_utc", "step", "channel", "latitude", "longitude")
-    assert len(np.unique(da.coords["channel"])) == da.shape[2]
+
+def test_load_ukv_rejects_x_y_coords(tmp_path):
+    """Test UKV data must use canonical OSGB coordinate names."""
+    zarr_path = tmp_path / "ukv_x_y_coords.zarr"
+    array = DataArray(
+        np.random.rand(1, 1, 1, 1, 1).astype(np.float32),
+        dims=("init_time_utc", "step", "channel", "x", "y"),
+        coords={
+            "init_time_utc": [np.datetime64("2023-01-01")],
+            "step": [np.timedelta64(1, "h")],
+            "channel": ["t"],
+            "x": [0],
+            "y": [50],
+        },
+    )
+    array.to_zarr(zarr_path)
+
+    with pytest.raises(ValueError, match="Expected coordinate 'x_osgb' missing"):
+        open_nwp(zarr_path=zarr_path, provider="ukv")
 
 
-def test_load_ecmwf_bad_dtype_latitude(tmp_path):
-    """Test validation fails for ECMWF with bad latitude dtype."""
-    zarr_path = tmp_path / "bad_ecmwf_latitude.zarr"
-    bad_array = DataArray(
+def test_load_ecmwf_integer_latitude(tmp_path):
+    """Test integer spatial coordinates are accepted."""
+    zarr_path = tmp_path / "integer_ecmwf_latitude.zarr"
+    array = DataArray(
         np.random.rand(1, 1, 1, 1, 1).astype(np.float32),
         dims=("init_time_utc", "step", "variable", "longitude", "latitude"),
         coords={
@@ -84,9 +89,10 @@ def test_load_ecmwf_bad_dtype_latitude(tmp_path):
             "latitude": [50],
         },
     )
-    bad_array.to_zarr(zarr_path)
-    with pytest.raises(TypeError, match="'latitude' for ecmwf should be floating"):
-        open_nwp(zarr_path=zarr_path, provider="ecmwf")
+    array.to_zarr(zarr_path)
+    da = open_nwp(zarr_path=zarr_path, provider="ecmwf")
+
+    assert np.issubdtype(da.latitude.dtype, np.integer)
 
 
 def test_load_ecmwf_bad_dtype_init_time(tmp_path):
@@ -123,7 +129,10 @@ def test_load_ecmwf_bad_dtype_step(tmp_path):
         },
     )
     bad_array.to_zarr(zarr_path)
-    with pytest.raises(TypeError, match="'step' for ecmwf should be timedelta64"):
+    with pytest.raises(
+        TypeError,
+        match="Coordinate 'step' in NWP provider 'ecmwf' should be timedelta64",
+    ):
         open_nwp(zarr_path=zarr_path, provider="ecmwf")
 
 
@@ -142,12 +151,15 @@ def test_load_ukv_bad_dtype_step(tmp_path):
         },
     )
     bad_array.to_zarr(zarr_path)
-    with pytest.raises(TypeError, match="'step' for ukv should be timedelta64"):
+    with pytest.raises(
+        TypeError,
+        match="Coordinate 'step' in NWP provider 'ukv' should be timedelta64",
+    ):
         open_nwp(zarr_path=zarr_path, provider="ukv")
 
 
 def test_load_ecmwf_bad_dtype_longitude(tmp_path):
-    """Test validation fails for ECMWF with bad longitude dtype."""
+    """Test validation fails for ECMWF with a non-numeric longitude dtype."""
     zarr_path = tmp_path / "bad_ecmwf_longitude.zarr"
     bad_array = DataArray(
         np.random.rand(1, 1, 1, 1, 1).astype(np.float32),
@@ -156,10 +168,13 @@ def test_load_ecmwf_bad_dtype_longitude(tmp_path):
             "init_time_utc": [np.datetime64("2023-01-01")],
             "step": [np.timedelta64(1, "h")],
             "variable": ["t"],
-            "longitude": [0],
+            "longitude": ["west"],
             "latitude": np.array([50.0], dtype=np.float32),
         },
     )
     bad_array.to_zarr(zarr_path)
-    with pytest.raises(TypeError, match="'longitude' for ecmwf should be floating"):
+    with pytest.raises(
+        TypeError,
+        match="Coordinate 'longitude' in NWP provider 'ecmwf' should be number",
+    ):
         open_nwp(zarr_path=zarr_path, provider="ecmwf")

--- a/tests/load/test_load_satellite.py
+++ b/tests/load/test_load_satellite.py
@@ -29,13 +29,13 @@ def test_open_satellite_bad_dtype(tmp_path: Path):
     bad_ds = xr.Dataset(
         data_vars={
             "data": (
-                ("time", "variable", "y_geostationary", "x_geostationary"),
+                ("time_utc", "channel", "y_geostationary", "x_geostationary"),
                 np.random.rand(10, 2, 4, 4),
             ),
         },
         coords={
-            "time": pd.date_range("2023-01-01", periods=10, freq="5min"),
-            "variable": [1, 2],
+            "time_utc": pd.date_range("2023-01-01", periods=10, freq="5min"),
+            "channel": [1, 2],
             "y_geostationary": np.arange(4),
             "x_geostationary": np.arange(4),
         },
@@ -43,26 +43,8 @@ def test_open_satellite_bad_dtype(tmp_path: Path):
     )
     bad_ds.to_zarr(zarr_path)
 
-    with pytest.raises(TypeError, match="channel should be str_"):
-        open_sat_data(zarr_path=zarr_path)
-
-
-def test_open_satellite_bad_dtype_spatial_coords(tmp_path: Path):
-    """Test that open_sat_data raises when spatial coords are not floating-point."""
-    zarr_path = tmp_path / "bad_sat_spatial.zarr"
-    bad_ds = xr.Dataset(
-        data_vars={
-            "data": (("time", "variable", "y_geostationary", "x_geostationary"),
-            np.random.rand(5, 2, 4, 4)),
-        },
-        coords={
-            "time": pd.date_range("2023-01-01", periods=5, freq="5min"),
-            "variable": ["IR_016", "IR_039"],
-            "y_geostationary": np.arange(4),
-            "x_geostationary": np.arange(4),
-        },
-        attrs={"area": "area_info"},
-    )
-    bad_ds.to_zarr(zarr_path)
-    with pytest.raises(TypeError, match="geostationary should be floating"):
+    with pytest.raises(
+        TypeError,
+        match="Coordinate 'channel' in satellite data should be str_",
+    ):
         open_sat_data(zarr_path=zarr_path)


### PR DESCRIPTION
# Pull Request

## Description

Blocked by #418 

This PR refactors the load NWP module to make it cleaner and more minimal. In doing this I refactored a few neighbouring files to share functionality and move some functions around to better locations.

Changes include
- Remove support for the GFS dataset in its current format
- Remove support for the ICON-EU dataset in its current format
- Remove support for UKV to have coords named `x` and `y`. They must explicitly be `x_osgb` and `y_osgb`
- Consolidate out xarray-tensortore functions for opening zarrs. There is now only one public function to open zarrs instead of 3
- Consolidate our list of NWP providers so we don't have to duplicate it. The same list was copied in 3 places
- Remove support for the `public` parameter in config and data loaders. We don't have a use for this, and it can be bypassed by the user setting their AWS/GCP/etc credentials globally
- Refactor the loading and validation functions in `load/nwp.py`
- Fix typos
- Change the expected dtypes of different coordinates and data to be the minimal we need to check. E.g. spatial coords can be floats or ints, data must be float
- Add more validation to the data and coordinate shapes
- Type-hinting improvements
- Rename `get_xr_data_array_from_xr_dataset() -> extract_single_data_array()` to be less cumbersome of a name
- Small updates satellite loader and tests for the new satellite dataset format

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
