### PR TITLE
Upgrade spatial window slicing

### DIFF
--- a/src/ocf_data_sampler/config/model.py
+++ b/src/ocf_data_sampler/config/model.py
@@ -138,13 +138,13 @@ class SpatialWindowMixin(Base):
 
     image_size_pixels_height: int = Field(
         ...,
-        ge=0,
+        gt=0,
         description="The number of pixels of the height of the region of interest",
     )
 
     image_size_pixels_width: int = Field(
         ...,
-        ge=0,
+        gt=0,
         description="The number of pixels of the width of the region of interest",
     )
 

--- a/src/ocf_data_sampler/select/spatial_slice.py
+++ b/src/ocf_data_sampler/select/spatial_slice.py
@@ -18,7 +18,9 @@ def _get_central_index(
     Args:
         values: The array of values to search.
         val: The value to find the closest index for.
-        method: Method to use for finding the index ("nearest" or "left").
+        method: Method to use for finding the index ("nearest" or "left"). If set to "nearest", the
+            index of the closest value will be returned. If set to "left", the index of the closest
+            value that is less than or equal to `val` will be returned.
 
     Returns:
         The index of the closest value.
@@ -32,17 +34,14 @@ def _get_central_index(
             f"{val} is not in the interval {values[0]}: {values[-1]}",
         )
 
-    def get_nearest_index(vals: np.ndarray, val: float) -> int:
-        """Get the index of the nearest value in vals to val."""
-        idx = np.searchsorted(vals, val, side="left") - 1
-        if idx < len(vals) - 1 and (abs(vals[idx+1] - val) < abs(vals[idx] - val)):
-            idx += 1
-        return idx
-
     if method == "left":
+        # Get the index of the closest value that is less than or equal to val
         index = np.searchsorted(values, val, side="right") - 1
     elif method == "nearest":
-        index = get_nearest_index(values, val)
+        # Get the index of the closest value to val
+        index = np.searchsorted(values, val, side="left") - 1
+        if index < len(values) - 1 and (abs(values[index+1] - val) < abs(values[index] - val)):
+            index += 1
     else:
         raise ValueError(f"Unknown method: {method}")
 
@@ -91,6 +90,7 @@ def _validate_window_slice(
         issue_details = "\n - ".join(issues)
         raise ValueError(f"Slice is unavailable:\n - {issue_details}")
 
+
 def select_spatial_slice_pixels(
     da: TArray,
     location: Location,
@@ -115,8 +115,8 @@ def select_spatial_slice_pixels(
     x_values = da[x_dim].values
     y_values = da[y_dim].values
 
-    # If odd window size, get index of nearest pixel, else get index of left pixel to ensure the
-    # location is within the returned slice
+    # If odd window size, get index of nearest pixel, else get index of closest pixel to the left
+    # to ensure the location is centred within the returned slice
     x_method = "nearest" if (width_pixels % 2) == 1 else "left"
     y_method = "nearest" if (height_pixels % 2) == 1 else "left"
     x_index = _get_central_index(x_values, x, method=x_method)

--- a/src/ocf_data_sampler/select/spatial_slice.py
+++ b/src/ocf_data_sampler/select/spatial_slice.py
@@ -1,46 +1,95 @@
 """Select spatial slices."""
 
+from typing import Literal
+
 import numpy as np
 
-from ocf_data_sampler.common.types import DataArrayLike, TArray
+from ocf_data_sampler.common.types import TArray
 from ocf_data_sampler.spatial import Location, find_coord_system
 
 
-def _get_pixel_index_location(da: DataArrayLike, location: Location) -> tuple[int, int]:
-    """Find pixel index location closest to given Location.
+def _get_central_index(
+    values: np.ndarray,
+    val: float,
+    method: Literal["nearest", "left"],
+) -> int:
+    """Find pixel index location closest to given value.
 
     Args:
-        da: The DataArray-like object.
-        location: The Location object representing the point of interest.
+        values: The array of values to search.
+        val: The value to find the closest index for.
+        method: Method to use for finding the index ("nearest" or "left").
 
     Returns:
-        The pixel indices.
+        The index of the closest value.
 
     Raises:
-        ValueError: If the location is outside the bounds of the DataArray.
+        ValueError: If the value is outside the bounds of the array.
     """
-    target_coords, x_dim, y_dim = find_coord_system(da)
-
-    x, y = location.in_coord_system(target_coords)
-
-    x_vals = da[x_dim].values
-    y_vals = da[y_dim].values
-
     # Check that requested point lies within the data
-    if not (x_vals[0] < x < x_vals[-1]):
+    if not (values[0] < val < values[-1]):
         raise ValueError(
-            f"{x} is not in the interval {x_vals[0]}: {x_vals[-1]}",
-        )
-    if not (y_vals[0] < y < y_vals[-1]):
-        raise ValueError(
-            f"{y} is not in the interval {y_vals[0]}: {y_vals[-1]}",
+            f"{val} is not in the interval {values[0]}: {values[-1]}",
         )
 
-    closest_x = np.argmin(np.abs(x_vals - x))
-    closest_y = np.argmin(np.abs(y_vals - y))
+    def get_nearest_index(vals: np.ndarray, val: float) -> int:
+        """Get the index of the nearest value in vals to val."""
+        idx = np.searchsorted(vals, val, side="left") - 1
+        if idx < len(vals) - 1 and (abs(vals[idx+1] - val) < abs(vals[idx] - val)):
+            idx += 1
+        return idx
 
-    return closest_x, closest_y
+    if method == "left":
+        index = np.searchsorted(values, val, side="left") - 1
+    elif method == "nearest":
+        index = get_nearest_index(values, val)
+    else:
+        raise ValueError(f"Unknown method: {method}")
 
+    return index
+
+
+def _get_window_bounds(
+    central_index: int,
+    window_size: int,
+) -> tuple[int, int]:
+    """Get the lower and upper bounds of a window around a central index."""
+    low_pad = (window_size+1)//2 - 1
+    high_pad = window_size//2 + 1
+
+    low_idx = int(central_index - low_pad)
+    high_idx = int(central_index + high_pad)
+
+    return low_idx, high_idx
+
+
+def _validate_window_slice(
+    window_slice: tuple[int, int, int, int],
+    total_size: tuple[int, int],
+) -> None:
+    """Validate that the window slice is within the bounds of the data."""
+    left_idx, right_idx, bottom_idx, top_idx = window_slice
+    total_width, total_height = total_size
+
+    slice_unavailable = (
+        left_idx < 0
+        or right_idx > total_width
+        or bottom_idx < 0
+        or top_idx > total_height
+    )
+
+    if slice_unavailable:
+        issues = []
+        if left_idx < 0:
+            issues.append(f"left index ({left_idx}) < 0")
+        if right_idx > total_width:
+            issues.append(f"right index ({right_idx}) > total_width ({total_width})")
+        if bottom_idx < 0:
+            issues.append(f"bottom index ({bottom_idx}) < 0")
+        if top_idx > total_height:
+            issues.append(f"top index ({top_idx}) > total_height ({total_height})")
+        issue_details = "\n - ".join(issues)
+        raise ValueError(f"Slice is unavailable:\n - {issue_details}")
 
 def select_spatial_slice_pixels(
     da: TArray,
@@ -57,50 +106,32 @@ def select_spatial_slice_pixels(
         width_pixels: Width of the slice in pixels
 
     Returns:
-        The selected DataArray slice.
-
-    Raises:
-        ValueError: If the window dimensions are not even or the slice extends beyond the data
-            boundaries.
+        The selected DataArray-like slice.
     """
-    if (width_pixels % 2) != 0:
-        raise ValueError("Width must be an even number")
-    if (height_pixels % 2) != 0:
-        raise ValueError("Height must be an even number")
+    target_coords, x_dim, y_dim = find_coord_system(da)
 
-    _, x_dim, y_dim = find_coord_system(da)
-    center_idx_x, center_idx_y = _get_pixel_index_location(da, location)
+    x, y = location.in_coord_system(target_coords)
 
-    half_width = width_pixels // 2
-    half_height = height_pixels // 2
+    x_values = da[x_dim].values
+    y_values = da[y_dim].values
 
-    left_idx = int(center_idx_x - half_width)
-    right_idx = int(center_idx_x + half_width)
-    bottom_idx = int(center_idx_y - half_height)
-    top_idx = int(center_idx_y + half_height)
+    # If odd window size, get index of nearest pixel, else get index of left pixel to ensure the
+    # location is within the returned slice
+    x_method = "nearest" if (width_pixels % 2) == 1 else "left"
+    y_method = "nearest" if (height_pixels % 2) == 1 else "left"
+    x_index = _get_central_index(x_values, x, method=x_method)
+    y_index = _get_central_index(y_values, y, method=y_method)
 
-    data_width_pixels = len(da[x_dim])
-    data_height_pixels = len(da[y_dim])
+    left_idx, right_idx = _get_window_bounds(x_index, width_pixels)
+    bottom_idx, top_idx = _get_window_bounds(y_index, height_pixels)
 
-    slice_unavailable = (
-        left_idx < 0
-        or right_idx > data_width_pixels
-        or bottom_idx < 0
-        or top_idx > data_height_pixels
+    data_width_pixels = len(x_values)
+    data_height_pixels = len(y_values)
+
+    _validate_window_slice(
+        window_slice=(left_idx, right_idx, bottom_idx, top_idx),
+        total_size=(data_width_pixels, data_height_pixels),
     )
-
-    if slice_unavailable:
-        issues = []
-        if left_idx < 0:
-            issues.append(f"left_idx ({left_idx}) < 0")
-        if right_idx > data_width_pixels:
-            issues.append(f"right_idx ({right_idx}) > data_width_pixels ({data_width_pixels})")
-        if bottom_idx < 0:
-            issues.append(f"bottom_idx ({bottom_idx}) < 0")
-        if top_idx > data_height_pixels:
-            issues.append(f"top_idx ({top_idx}) > data_height_pixels ({data_height_pixels})")
-        issue_details = "\n - ".join(issues)
-        raise ValueError(f"Window for location {location} not available: \n - {issue_details}")
 
     return da.isel({x_dim: slice(left_idx, right_idx), y_dim: slice(bottom_idx, top_idx)})
 
@@ -120,21 +151,18 @@ def select_spatial_slice_pixels_multiple(
         width_pixels: Width of the slice in pixels
 
     Returns:
-        The selected DataArray slice.
-
-    Raises:
-        ValueError: If the window dimensions are not even or the slice extends beyond the data
-            boundaries.
+        The selected DataArray-like slice.
     """
-    if (width_pixels % 2) != 0:
-        raise ValueError("Width must be an even number")
-    if (height_pixels % 2) != 0:
-        raise ValueError("Height must be an even number")
+    target_coords, x_dim, y_dim = find_coord_system(da)
 
-    _, x_dim, y_dim = find_coord_system(da)
+    x_values = da[x_dim].values
+    y_values = da[y_dim].values
 
-    data_width_pixels = len(da[x_dim])
-    data_height_pixels = len(da[y_dim])
+    x_method = "nearest" if (width_pixels % 2) == 1 else "left"
+    y_method = "nearest" if (height_pixels % 2) == 1 else "left"
+
+    data_width_pixels = len(x_values)
+    data_height_pixels = len(y_values)
 
     idx_x_min: int = data_width_pixels
     idx_x_max: int = 0
@@ -142,43 +170,22 @@ def select_spatial_slice_pixels_multiple(
     idx_y_max: int = 0
 
     for location in locations:
-        center_idx_x, center_idx_y = _get_pixel_index_location(da, location)
-        idx_x_min = min(idx_x_min, center_idx_x)
-        idx_x_max = max(idx_x_max, center_idx_x)
-        idx_y_min = min(idx_y_min, center_idx_y)
-        idx_y_max = max(idx_y_max, center_idx_y)
+        x, y = location.in_coord_system(target_coords)
+        x_index = _get_central_index(x_values, x, method=x_method)
+        y_index = _get_central_index(y_values, y, method=y_method)
+        idx_x_min = min(idx_x_min, x_index)
+        idx_x_max = max(idx_x_max, x_index)
+        idx_y_min = min(idx_y_min, y_index)
+        idx_y_max = max(idx_y_max, y_index)
 
-    half_width = width_pixels // 2
-    half_height = height_pixels // 2
+    left_idx, _ = _get_window_bounds(idx_x_min, width_pixels)
+    _, right_idx = _get_window_bounds(idx_x_max, width_pixels)
+    bottom_idx, _ = _get_window_bounds(idx_y_min, height_pixels)
+    _, top_idx = _get_window_bounds(idx_y_max, height_pixels)
 
-    left_idx = int(idx_x_min - half_width)
-    right_idx = int(idx_x_max + half_width)
-    bottom_idx = int(idx_y_min - half_height)
-    top_idx = int(idx_y_max + half_height)
-
-    slice_unavailable = (
-        left_idx < 0
-        or right_idx > data_width_pixels
-        or bottom_idx < 0
-        or top_idx > data_height_pixels
+    _validate_window_slice(
+        window_slice=(left_idx, right_idx, bottom_idx, top_idx),
+        total_size=(data_width_pixels, data_height_pixels),
     )
 
-    if slice_unavailable:
-        raise ValueError(
-            "Multi-location window not available: "
-            f"left_idx ({left_idx}), right_idx ({right_idx}), "
-            f"bottom_idx ({bottom_idx}), top_idx ({top_idx}), "
-            f"data_width_pixels ({data_width_pixels}), data_height_pixels ({data_height_pixels})",
-        )
-
-    # Add buffer of 1 pixel if window is 2 pixels wide to ensure the central location is within the
-    # returned slice
-    x_buffer = 1 if width_pixels==2 else 0
-    y_buffer = 1 if height_pixels==2 else 0
-
-    return da.isel(
-        {
-            x_dim: slice(left_idx, right_idx+x_buffer),
-            y_dim: slice(bottom_idx, top_idx+y_buffer),
-        },
-    )
+    return da.isel({x_dim: slice(left_idx, right_idx), y_dim: slice(bottom_idx, top_idx)})

--- a/src/ocf_data_sampler/select/spatial_slice.py
+++ b/src/ocf_data_sampler/select/spatial_slice.py
@@ -40,7 +40,7 @@ def _get_central_index(
         return idx
 
     if method == "left":
-        index = np.searchsorted(values, val, side="left") - 1
+        index = np.searchsorted(values, val, side="right") - 1
     elif method == "nearest":
         index = get_nearest_index(values, val)
     else:

--- a/src/ocf_data_sampler/select/time_slice.py
+++ b/src/ocf_data_sampler/select/time_slice.py
@@ -54,8 +54,8 @@ def select_time_slice_nwp(
     if dropout_timedeltas is None:
         dropout_timedeltas = np.array([], dtype="timedelta64[ns]")
 
-    if len(dropout_timedeltas)>0 and np.any(dropout_timedeltas >= np.timedelta64(0)):
-        raise ValueError("dropout timedeltas must be negative")
+    if len(dropout_timedeltas) > 0 and np.any(dropout_timedeltas >= np.timedelta64(0)):
+            raise ValueError("dropout timedeltas must be negative")
 
     if not (0 <= dropout_frac <= 1):
         raise ValueError("`dropout_frac` must be between 0 and 1")

--- a/src/ocf_data_sampler/select/time_slice.py
+++ b/src/ocf_data_sampler/select/time_slice.py
@@ -55,7 +55,7 @@ def select_time_slice_nwp(
         dropout_timedeltas = np.array([], dtype="timedelta64[ns]")
 
     if len(dropout_timedeltas) > 0 and np.any(dropout_timedeltas >= np.timedelta64(0)):
-            raise ValueError("dropout timedeltas must be negative")
+        raise ValueError("dropout timedeltas must be negative")
 
     if not (0 <= dropout_frac <= 1):
         raise ValueError("`dropout_frac` must be between 0 and 1")

--- a/tests/select/conftest.py
+++ b/tests/select/conftest.py
@@ -35,17 +35,3 @@ def da_sample():
         np.random.normal(size=(len(datetimes),)),
         coords={"time_utc": (["time_utc"], datetimes)},
     )
-
-
-@pytest.fixture(scope="module")
-def da():
-    """Create dummy 2D spatial data"""
-    x = np.arange(-100, 100)
-    y = np.arange(-100, 100)
-    return xr.DataArray(
-        np.random.normal(size=(len(x), len(y))),
-        coords={
-            "x_osgb": (["x_osgb"], x),
-            "y_osgb": (["y_osgb"], y),
-        },
-    )

--- a/tests/select/test_spatial_slice.py
+++ b/tests/select/test_spatial_slice.py
@@ -3,42 +3,108 @@ import pytest
 import xarray as xr
 
 from ocf_data_sampler.select.spatial_slice import (
-    _get_pixel_index_location,
+    _get_central_index,
+    _get_window_bounds,
     select_spatial_slice_pixels,
 )
 from ocf_data_sampler.spatial import Location
 
 
-def test_get_idx_of_pixel_closest_to_poi(da):
-    idx_location = _get_pixel_index_location(da, location=Location(x=10, y=10, coord_system="osgb"))
-    assert idx_location == (110, 110)
+@pytest.fixture(scope="module")
+def da():
+    """Create dummy 2D spatial data"""
+    x = np.arange(-100, 100)
+    y = np.arange(-100, 100)
+    return xr.DataArray(
+        np.random.normal(size=(len(x), len(y))),
+        coords={
+            "x_osgb": (["x_osgb"], x),
+            "y_osgb": (["y_osgb"], y),
+        },
+    )
+
+@pytest.mark.parametrize(
+    "x_query, expected_xval, method",
+    [
+        (4.1, 4, "nearest"),
+        (3.9, 4, "nearest"),
+        (4, 4, "nearest"),
+        (4.1, 4, "left"),
+        (3.9, 3, "left"),
+        (4, 4, "nearest"),
+    ],
+)
+def test_get_central_index(x_query, expected_xval, method):
+    x_vals = np.arange(0, 10)
+    index = _get_central_index(x_vals, x_query, method=method)
+    assert x_vals[index] == expected_xval
+
+
+@pytest.mark.parametrize(
+    "central_index, window_size, expected_slice",
+    [
+        (5, 2, (5, 7)),
+        (5, 3, (4, 7)),
+        (5, 4, (4, 8)),
+        (5, 5, (3, 8)),
+    ]
+)
+def test_get_window_bounds(central_index, window_size, expected_slice):
+    index_slice = _get_window_bounds(central_index, window_size)
+    assert index_slice == expected_slice
 
 
 def test_select_spatial_slice_pixels(da):
-    # Select window which lies within x-y bounds of the data
+
+    # Select odd sized window
     da_sliced = select_spatial_slice_pixels(
         da,
-        location=Location(x=-90, y=-80, coord_system="osgb"),
-        width_pixels=10,
-        height_pixels=10,
+        location=Location(x=10.1, y=-4.9, coord_system="osgb"),
+        width_pixels=3,
+        height_pixels=3,
     )
 
-    assert isinstance(da_sliced, xr.DataArray)
-    assert (da_sliced["x_osgb"].values == np.arange(-95, -85)).all()
-    assert (da_sliced["y_osgb"].values == np.arange(-85, -75)).all()
+    assert (da_sliced["x_osgb"].values == np.array([9, 10, 11])).all()
+    assert (da_sliced["y_osgb"].values == np.array([-6, -5, -4])).all()
+    assert not da_sliced.isnull().any()
+
+
+    # Select even sized window
+    da_sliced = select_spatial_slice_pixels(
+        da,
+        location=Location(x=10.1, y=-4.9, coord_system="osgb"),
+        width_pixels=4,
+        height_pixels=4,
+    )
+
+    assert (da_sliced["x_osgb"].values == np.array([9, 10, 11, 12])).all()
+    assert (da_sliced["y_osgb"].values == np.array([-6, -5, -4, -3])).all()
+    assert not da_sliced.isnull().any()
+
+
+    # Select mixed odd and even sized window
+    da_sliced = select_spatial_slice_pixels(
+        da,
+        location=Location(x=10.1, y=-4.9, coord_system="osgb"),
+        width_pixels=3,
+        height_pixels=4,
+    )
+
+    assert (da_sliced["x_osgb"].values == np.array([9, 10, 11])).all()
+    assert (da_sliced["y_osgb"].values == np.array([-6, -5, -4, -3])).all()
     assert not da_sliced.isnull().any()
 
     # Select window where the edge of the window lies right on the edge of the data
     da_sliced = select_spatial_slice_pixels(
         da,
-        location=Location(x=-90, y=-80, coord_system="osgb"),
+        location=Location(x=-90.1, y=89.9, coord_system="osgb"),
         width_pixels=20,
         height_pixels=20,
     )
 
     assert isinstance(da_sliced, xr.DataArray)
     assert (da_sliced["x_osgb"].values == np.arange(-100, -80)).all()
-    assert (da_sliced["y_osgb"].values == np.arange(-90, -70)).all()
+    assert (da_sliced["y_osgb"].values == np.arange(80, 100)).all()
     assert not da_sliced.isnull().any()
 
 
@@ -47,19 +113,19 @@ def test_select_spatial_slice_pixels_out_of_bounds(da):
     with pytest.raises(ValueError) as excinfo:
         select_spatial_slice_pixels(
             da,
-            location=Location(x=-90, y=-80, coord_system="osgb"),
+            location=Location(x=-90.1, y=-80.1, coord_system="osgb"),
             width_pixels=30,
             height_pixels=30,
         )
     msg = str(excinfo.value)
-    assert "not available" in msg
+    assert "Slice is unavailable:" in msg
 
     with pytest.raises(ValueError) as excinfo:
         select_spatial_slice_pixels(
             da,
-            location=Location(x=90, y=90, coord_system="osgb"),
+            location=Location(x=90.1, y=90.1, coord_system="osgb"),
             width_pixels=40,
             height_pixels=40,
         )
     msg = str(excinfo.value)
-    assert "not available" in msg
+    assert "Slice is unavailable:" in msg

--- a/tests/select/test_spatial_slice.py
+++ b/tests/select/test_spatial_slice.py
@@ -31,7 +31,7 @@ def da():
         (4, 4, "nearest"),
         (4.1, 4, "left"),
         (3.9, 3, "left"),
-        (4, 4, "nearest"),
+        (4, 4, "left"),
     ],
 )
 def test_get_central_index(x_query, expected_xval, method):


### PR DESCRIPTION
# Pull Request

## Description

We noted some shortcoming in our spatial window slicing in #411 where depending on the configuration the desired location would not be in the centre of the image. 

This PR upgrades our spatial slicing to:
- Fix the spatial slicing so the desired location is always in the centre
- Allow spatial slices with odd sized windows
- Refactor the surrounding code to make this all cleaner
- Add to the tests to lock in this behaviour

Solves #411

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
