### PR TITLE
Improve NWP dropout argument passing

### DIFF
--- a/src/ocf_data_sampler/config/model.py
+++ b/src/ocf_data_sampler/config/model.py
@@ -124,12 +124,14 @@ class DropoutMixin(Base):
     @model_validator(mode="after")
     def dropout_instructions_consistent(self) -> "DropoutMixin":
         """Validator for dropout instructions."""
-        if isinstance(self.dropout_fraction, list):
-            if len(self.dropout_fraction) != len(self.dropout_timedeltas_minutes):
-                raise ValueError(
-                    "When `dropout_fraction` is a list, it must have the same length as "
-                    "`dropout_timedeltas_minutes`"
-                )
+        if (
+            isinstance(self.dropout_fraction, list)
+            and len(self.dropout_fraction) != len(self.dropout_timedeltas_minutes)
+        ):
+            raise ValueError(
+                "When `dropout_fraction` is a list, it must have the same length as "
+                "`dropout_timedeltas_minutes`"
+            )
 
         if self.dropout_fraction == 0:
             if self.dropout_timedeltas_minutes != []:

--- a/src/ocf_data_sampler/config/model.py
+++ b/src/ocf_data_sampler/config/model.py
@@ -124,6 +124,13 @@ class DropoutMixin(Base):
     @model_validator(mode="after")
     def dropout_instructions_consistent(self) -> "DropoutMixin":
         """Validator for dropout instructions."""
+        if isinstance(self.dropout_fraction, list):
+            if len(self.dropout_fraction) != len(self.dropout_timedeltas_minutes):
+                raise ValueError(
+                    "When `dropout_fraction` is a list, it must have the same length as "
+                    "`dropout_timedeltas_minutes`"
+                )
+
         if self.dropout_fraction == 0:
             if self.dropout_timedeltas_minutes != []:
                 raise ValueError("To use dropout timedeltas dropout fraction should be > 0")
@@ -254,7 +261,6 @@ class NWP(TimeWindowMixin, DropoutMixin, SpatialWindowMixin, NormalisationConsta
             supported = ", ".join(sorted(PROVIDER_REGISTRY))
             raise ValueError(f"Unknown NWP provider {v!r}. Supported: {supported}")
         return provider
-
 
     @model_validator(mode="after")
     def check_all_channel_have_normalisation_constants(self) -> "NWP":

--- a/src/ocf_data_sampler/datasets/pvnet/dataset.py
+++ b/src/ocf_data_sampler/datasets/pvnet/dataset.py
@@ -247,6 +247,21 @@ class AbstractPVNetDataset(PickleCacheMixin, Dataset):
         self.clip_min_dict = clip_min_dict
         self.clip_max_dict = clip_max_dict
 
+    def _sanitise_index(self, idx: int) -> int:
+        """Sanitise dataset indexing and raise IndexError for out-of-range indices."""
+        if isinstance(idx, bool) or not isinstance(idx, (int, np.integer)):
+            raise TypeError(f"Dataset indices must be integers, got {type(idx)!r}")
+
+        index = int(idx)
+        n_samples = len(self)
+        if index < 0:
+            index += n_samples
+
+        if index < 0 or index >= n_samples:
+            raise IndexError(f"Index {idx} out of range for dataset of length {n_samples}")
+
+        return index
+
     def process_and_combine_datasets(
         self,
         dataset_dict: SourceDict,
@@ -443,10 +458,9 @@ class PVNetDataset(AbstractPVNetDataset):
 
     @override
     def __getitem__(self, idx: int) -> NumpySample:
-        # Get the coordinates of the sample
-        if idx >= len(self):
-            raise ValueError(f"Index {idx} out of range for dataset of length {len(self)}")
+        idx = self._normalise_index(idx)
 
+        # Get the coordinates of the sample
         if self.complete_generation:
             # t_index will be between 0 and len(self.valid_t0_times)-1
             t_index = idx % len(self.valid_t0_times)
@@ -550,6 +564,7 @@ class PVNetConcurrentDataset(AbstractPVNetDataset):
 
     @override
     def __getitem__(self, idx: int) -> TensorBatch:
+        idx = self._normalise_index(idx)
         return self._get_sample(self.valid_t0_times[idx])
 
     def get_sample(self, t0: np.datetime64) -> TensorBatch:

--- a/src/ocf_data_sampler/datasets/pvnet/dataset.py
+++ b/src/ocf_data_sampler/datasets/pvnet/dataset.py
@@ -458,7 +458,7 @@ class PVNetDataset(AbstractPVNetDataset):
 
     @override
     def __getitem__(self, idx: int) -> NumpySample:
-        idx = self._normalise_index(idx)
+        idx = self._sanitise_index(idx)
 
         # Get the coordinates of the sample
         if self.complete_generation:
@@ -564,7 +564,7 @@ class PVNetConcurrentDataset(AbstractPVNetDataset):
 
     @override
     def __getitem__(self, idx: int) -> TensorBatch:
-        idx = self._normalise_index(idx)
+        idx = self._sanitise_index(idx)
         return self._get_sample(self.valid_t0_times[idx])
 
     def get_sample(self, t0: np.datetime64) -> TensorBatch:

--- a/src/ocf_data_sampler/select/time_periods.py
+++ b/src/ocf_data_sampler/select/time_periods.py
@@ -173,7 +173,7 @@ def find_contiguous_t0_periods_nwp(
 
         if max_staleness < ZERO_TDELTA:
             raise ValueError("The max staleness must be non-negative (zero or positive)")
-        
+
         if max_dropout > max_staleness:
             raise ValueError(
                 f"max_dropout ({max_dropout}) must be <= max_staleness ({max_staleness})"

--- a/src/ocf_data_sampler/select/time_periods.py
+++ b/src/ocf_data_sampler/select/time_periods.py
@@ -167,12 +167,17 @@ def find_contiguous_t0_periods_nwp(
         raise ValueError("No init-times to use")
 
     if max_dropout < ZERO_TDELTA:
-        raise ValueError("The max dropout must be positive")
+        raise ValueError("The max dropout must be non-negative (zero or positive)")
 
     if max_staleness is not None:
 
         if max_staleness < ZERO_TDELTA:
-            raise ValueError("The max staleness must be positive")
+            raise ValueError("The max staleness must be non-negative (zero or positive)")
+        
+        if max_dropout > max_staleness:
+            raise ValueError(
+                f"max_dropout ({max_dropout}) must be <= max_staleness ({max_staleness})"
+            )
 
         # This is the max staleness we can use considering the max step of the input data
         max_possible_staleness = last_forecast_step - interval_end

--- a/src/ocf_data_sampler/select/time_slice.py
+++ b/src/ocf_data_sampler/select/time_slice.py
@@ -47,8 +47,8 @@ def select_time_slice_nwp(
     interval_start: np.timedelta64,
     interval_end: np.timedelta64,
     time_resolution: np.timedelta64,
-    dropout_timedeltas: NDArray[np.timedelta64] | None = None,
-    dropout_frac: float = 0,
+    dropout_timedeltas: NDArray[np.timedelta64] | None,
+    dropout_frac: float | list[float],
 ) -> TArray:
     """Select a time slice from an NWP DataArray.
 
@@ -59,18 +59,10 @@ def select_time_slice_nwp(
         interval_end: The end of the interval with respect to t0
         time_resolution: Distance between neighbouring timestamps
         dropout_timedeltas: List of possible timedeltas before t0 where data availability may start
-        dropout_frac: Probability to apply dropout
+        dropout_frac: Either a float dropout probability or a list of per-timedelta
+            probabilities. For list inputs, values must be in [0, 1], sum to <= 1,
+            and match `dropout_timedeltas` length.
     """
-    if dropout_timedeltas is None:
-        dropout_timedeltas = np.array([], dtype="timedelta64[ns]")
-
-    if len(dropout_timedeltas) > 0 and np.any(dropout_timedeltas >= np.timedelta64(0)):
-        raise ValueError("dropout timedeltas must be negative")
-
-    if not (0 <= dropout_frac <= 1):
-        raise ValueError("`dropout_frac` must be between 0 and 1")
-
-    consider_dropout = len(dropout_timedeltas) > 0 and dropout_frac > 0
 
     start_dt = t0 + interval_start
     end_dt = t0 + interval_end
@@ -81,11 +73,7 @@ def select_time_slice_nwp(
     all_init_times = da["init_time_utc"].values
     all_steps = da["step"].values
 
-    # Potentially apply NWP dropout
-    if consider_dropout and (np.random.uniform() < dropout_frac):
-        t0_available = t0 + np.random.choice(dropout_timedeltas)
-    else:
-        t0_available = t0
+    t0_available = _get_nwp_dropout_available_time(t0, dropout_timedeltas, dropout_frac)
 
     # Can't use an init-time if the start_dt is before its first step
     t0_available = min(t0_available, start_dt - all_steps[0])
@@ -108,3 +96,49 @@ def select_time_slice_nwp(
     selected_step_indices = get_indices_in_sorted_unique(all_steps, required_steps)
 
     return da.isel(init_time_utc=selected_init_time_index, step=selected_step_indices)
+
+
+def _get_nwp_dropout_available_time(
+    t0: np.datetime64,
+    dropout_timedeltas: NDArray[np.timedelta64] | None,
+    dropout_frac: float | list[float],
+) -> np.datetime64:
+    """Choose the available-time timestamp after applying configured dropout."""
+
+    if dropout_timedeltas is None or len(dropout_timedeltas) == 0 or dropout_frac == 0:
+        return t0
+
+    if np.any(dropout_timedeltas > np.timedelta64(0, "ns")):
+        raise ValueError("`dropout_timedeltas` must be negative or zero")
+
+    if isinstance(dropout_frac, float | int):
+        dropout_sum = dropout_frac
+        dropout_probs = [dropout_frac / len(dropout_timedeltas)] * len(dropout_timedeltas)
+        
+    else:
+        dropout_sum = sum(dropout_frac)
+        dropout_probs = [*dropout_frac]
+
+    if dropout_sum == 0:
+        return t0
+    
+    if not 0 <= dropout_sum <= 1:
+        raise ValueError(f"The sum of `dropout_frac` ({dropout_frac}) must be in range [0, 1]")
+    if not all([0 <= p <= 1 for p in dropout_probs]):
+        raise ValueError(f"All `dropout_frac` ({dropout_frac}) values must be in range [0, 1]")
+    if len(dropout_timedeltas) != len(dropout_probs):
+        raise ValueError(
+            "`dropout_timedeltas` and `dropout_frac` must have the same length or `dropout_frac` "
+            "must be a float"
+        )
+
+    dropout_choices: list[np.timedelta64 | None] = [*dropout_timedeltas]
+
+    # Add a None option to represent no dropout, with probability 1 - sum(dropout_frac)
+    dropout_choices.append(None)
+    dropout_probs.append(1 - dropout_sum)
+
+    selected_dropout = np.random.choice(dropout_choices, p=dropout_probs)
+    if selected_dropout is None:
+        return t0
+    return t0 + selected_dropout

--- a/src/ocf_data_sampler/select/time_slice.py
+++ b/src/ocf_data_sampler/select/time_slice.py
@@ -63,7 +63,6 @@ def select_time_slice_nwp(
             probabilities. For list inputs, values must be in [0, 1], sum to <= 1,
             and match `dropout_timedeltas` length.
     """
-
     start_dt = t0 + interval_start
     end_dt = t0 + interval_end
     start_dt, end_dt = datetime_ceil(np.array([start_dt, end_dt]), time_resolution)
@@ -104,7 +103,6 @@ def _get_nwp_dropout_available_time(
     dropout_frac: float | list[float],
 ) -> np.datetime64:
     """Choose the available-time timestamp after applying configured dropout."""
-
     if dropout_timedeltas is None or len(dropout_timedeltas) == 0 or dropout_frac == 0:
         return t0
 
@@ -114,17 +112,17 @@ def _get_nwp_dropout_available_time(
     if isinstance(dropout_frac, float | int):
         dropout_sum = dropout_frac
         dropout_probs = [dropout_frac / len(dropout_timedeltas)] * len(dropout_timedeltas)
-        
+
     else:
         dropout_sum = sum(dropout_frac)
         dropout_probs = [*dropout_frac]
 
     if dropout_sum == 0:
         return t0
-    
+
     if not 0 <= dropout_sum <= 1:
         raise ValueError(f"The sum of `dropout_frac` ({dropout_frac}) must be in range [0, 1]")
-    if not all([0 <= p <= 1 for p in dropout_probs]):
+    if not all(0 <= p <= 1 for p in dropout_probs):
         raise ValueError(f"All `dropout_frac` ({dropout_frac}) values must be in range [0, 1]")
     if len(dropout_timedeltas) != len(dropout_probs):
         raise ValueError(

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -123,6 +123,20 @@ def test_incorrect_dropout_fraction(config_filename):
         _validate_configuration(configuration)
 
 
+def test_dropout_fraction_list_length_matches_timedeltas(config_filename):
+    """List dropout fractions must align with dropout timedeltas one-to-one."""
+    configuration, provider = _load_config_and_provider(config_filename)
+
+    configuration.input_data.nwp[provider].dropout_timedeltas_minutes = [-60, -120]
+    configuration.input_data.nwp[provider].dropout_fraction = [0.5]
+
+    with pytest.raises(
+        ValidationError,
+        match="must have the same length as `dropout_timedeltas_minutes`",
+    ):
+        _validate_configuration(configuration)
+
+
 def test_inconsistent_dropout_use(config_filename):
     """
     Check dropout fraction outside of range causes error

--- a/tests/datasets/pvnet/test_dataset.py
+++ b/tests/datasets/pvnet/test_dataset.py
@@ -165,6 +165,21 @@ def test_pvnet_concurrent_dataset(pvnet_config_filename):
     _pvnet_dataset_sample_check(sample, dataset.config, (num_gsps,))
 
 
+def test_pvnet_dataset_getitem_bounds(pvnet_config_filename):
+    dataset = PVNetDataset(pvnet_config_filename)
+
+    sample_from_last = dataset[len(dataset) - 1]
+    sample_from_negative = dataset[-1]
+    assert sample_from_negative["t0"] == sample_from_last["t0"]
+    assert sample_from_negative["location_id"] == sample_from_last["location_id"]
+
+    with pytest.raises(IndexError):
+        _ = dataset[len(dataset)]
+
+    with pytest.raises(IndexError):
+        _ = dataset[-len(dataset) - 1]
+
+
 def test_solar_position_decoupling(tmp_path, pvnet_config_filename):
     """Test that solar position calculations are properly decoupled from data sources."""
     config = load_yaml_configuration(pvnet_config_filename)

--- a/tests/select/test_time_periods.py
+++ b/tests/select/test_time_periods.py
@@ -94,7 +94,7 @@ def test_find_contiguous_t0_periods_nwp():
         .values
     )
 
-    first_forecast_step = np.timedelta64(0)
+    first_forecast_step = np.timedelta64(0, "h")
     last_forecast_step = np.timedelta64(36, "h")
 
     interval_end = np.timedelta64(3, "h")

--- a/tests/select/test_time_slice.py
+++ b/tests/select/test_time_slice.py
@@ -151,13 +151,13 @@ def test_select_time_slice_nwp_with_weighted_dropout_list(da_nwp_like):
 
 def test_select_time_slice_nwp_rejects_invalid_weighted_dropout_inputs(da_nwp_like):
     """List dropout probabilities must satisfy sum and length constraints."""
-    kwargs = dict(
-        da=da_nwp_like,
-        t0=np.datetime64("2024-01-02 12:00"),
-        time_resolution=np.timedelta64(1, "h"),
-        interval_start=np.timedelta64(-2, "h"),
-        interval_end=np.timedelta64(3, "h"),
-    )
+    kwargs = {
+        "da": da_nwp_like,
+        "t0": np.datetime64("2024-01-02 12:00"),
+        "time_resolution": np.timedelta64(1, "h"),
+        "interval_start": np.timedelta64(-2, "h"),
+        "interval_end": np.timedelta64(3, "h"),
+    }
 
     with pytest.raises(ValueError, match="sum of `dropout_frac`"):
         select_time_slice_nwp(

--- a/tests/select/test_time_slice.py
+++ b/tests/select/test_time_slice.py
@@ -120,3 +120,55 @@ def test_select_time_slice_nwp_with_dropout(da_nwp_like, dropout_hours):
     init_times = da_nwp_like["init_time_utc"].values
     expected_init_time = init_times[init_times<=t0_delayed][-1]
     assert (expected_init_time == da_slice["init_time_utc"].values)
+
+
+def test_select_time_slice_nwp_with_weighted_dropout_list(da_nwp_like):
+    """List dropout probabilities should select the corresponding timedelta weights."""
+    t0 = np.datetime64("2024-01-02 12:00")
+    interval_start = np.timedelta64(-2, "h")
+    interval_end = np.timedelta64(3, "h")
+    freq = np.timedelta64(1, "h")
+
+    da_slice = select_time_slice_nwp(
+        da_nwp_like,
+        t0,
+        time_resolution=freq,
+        interval_start=interval_start,
+        interval_end=interval_end,
+        dropout_timedeltas=[np.timedelta64(-1, "h"), np.timedelta64(-2, "h")],
+        dropout_frac=[1.0, 0.0],
+    )
+
+    expected_target_times = date_range(t0 + interval_start, t0 + interval_end, freq=freq)
+    valid_times = da_slice["init_time_utc"] + da_slice["step"]
+    assert (valid_times == expected_target_times).all()
+
+    t0_delayed = min(t0 + np.timedelta64(-1, "h"), expected_target_times[0])
+    init_times = da_nwp_like["init_time_utc"].values
+    expected_init_time = init_times[init_times <= t0_delayed][-1]
+    assert (expected_init_time == da_slice["init_time_utc"].values)
+
+
+def test_select_time_slice_nwp_rejects_invalid_weighted_dropout_inputs(da_nwp_like):
+    """List dropout probabilities must satisfy sum and length constraints."""
+    kwargs = dict(
+        da=da_nwp_like,
+        t0=np.datetime64("2024-01-02 12:00"),
+        time_resolution=np.timedelta64(1, "h"),
+        interval_start=np.timedelta64(-2, "h"),
+        interval_end=np.timedelta64(3, "h"),
+    )
+
+    with pytest.raises(ValueError, match="sum of `dropout_frac`"):
+        select_time_slice_nwp(
+            **kwargs,
+            dropout_timedeltas=[np.timedelta64(-1, "h"), np.timedelta64(-2, "h")],
+            dropout_frac=[0.8, 0.4],
+        )
+
+    with pytest.raises(ValueError, match="must have the same length"):
+        select_time_slice_nwp(
+            **kwargs,
+            dropout_timedeltas=[np.timedelta64(-1, "h"), np.timedelta64(-2, "h")],
+            dropout_frac=[0.5],
+        )


### PR DESCRIPTION
# Pull Request

## Description

This PR has a few changes mostly related to the dropout used for NWPs

- Modify the `select_time_slice_nwp()` function so that it accepts a list of dropout probabilities linked to the dropout values. This matches the behaviour of the dropout function used for satellite and generation data. It also matches to what inputs already passes the pydantic checks in the the data config
- Refactor the `select_time_slice_nwp()` to make it easier to follow
- Add an additional validation check in the data config to make sure the dropout probability list (if configured with list instead of float) is the same length as the dropout times list
- Add a new method to sanity-check indexes requested from the dataset

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
